### PR TITLE
Fix date range filtering in transaction queries

### DIFF
--- a/internal/repository/transactions_repository.go
+++ b/internal/repository/transactions_repository.go
@@ -175,10 +175,11 @@ func (r *transactionsRepository) Delete(id uint) error {
 
 func (r *transactionsRepository) FindByDateRange(startDate, endDate time.Time) ([]model.Transaction, error) {
 	var transactions []model.Transaction
+	endOfDay := time.Date(endDate.Year(), endDate.Month(), endDate.Day()+1, 0, 0, 0, 0, endDate.Location())
 	err := r.db.Scopes(WithIsPrepaid).Where(
-		"(is_recurring = ? AND date >= ? AND date <= ?) OR (is_recurring = ? AND start_date <= ? AND (end_date >= ? OR end_date IS NULL))",
-		false, startDate, endDate,
-		true, endDate, startDate,
+		"(is_recurring = ? AND date >= ? AND date < ?) OR (is_recurring = ? AND start_date < ? AND (end_date >= ? OR end_date IS NULL))",
+		false, startDate, endOfDay,
+		true, endOfDay, startDate,
 	).
 		Order("date DESC").
 		Find(&transactions).Error

--- a/internal/repository/transactions_repository.go
+++ b/internal/repository/transactions_repository.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"log"
 	"time"
 
 	"github.com/ArthurWerle/transactions/internal/model"
@@ -176,6 +177,7 @@ func (r *transactionsRepository) Delete(id uint) error {
 func (r *transactionsRepository) FindByDateRange(startDate, endDate time.Time) ([]model.Transaction, error) {
 	var transactions []model.Transaction
 	endOfDay := time.Date(endDate.Year(), endDate.Month(), endDate.Day()+1, 0, 0, 0, 0, endDate.Location())
+	log.Printf("FindByDateRange: startDate=%s endDate=%s endOfDay=%s", startDate.Format(time.RFC3339), endDate.Format(time.RFC3339), endOfDay.Format(time.RFC3339))
 	err := r.db.Scopes(WithIsPrepaid).Where(
 		"(is_recurring = ? AND date >= ? AND date < ?) OR (is_recurring = ? AND start_date < ? AND (end_date >= ? OR end_date IS NULL))",
 		false, startDate, endOfDay,


### PR DESCRIPTION
## Summary
Fixed the date range filtering logic in `FindByDateRange` to correctly handle end-of-day boundaries and improve recurring transaction date matching.

## Key Changes
- **End-of-day boundary handling**: Calculate `endOfDay` as the start of the next day to properly include all transactions on the end date
- **Query operator adjustments**: Changed `<=` to `<` for non-recurring transactions (using `endOfDay` instead of `endDate`) and `<=` to `<` for recurring transaction start dates to ensure consistent boundary behavior
- **Debugging support**: Added logging to track the date range parameters being used in queries
- **Import addition**: Added `"log"` package import for debugging output

## Implementation Details
The fix addresses an off-by-one error in date range queries by:
1. Computing `endOfDay` as midnight of the day after `endDate`
2. Using `date < endOfDay` instead of `date <= endDate` for non-recurring transactions
3. Using `start_date < endOfDay` instead of `start_date <= endDate` for recurring transactions
4. Adding debug logging to help diagnose future date-related issues

This ensures transactions are correctly included/excluded at day boundaries, particularly important for recurring transactions that may span multiple days.

https://claude.ai/code/session_01KLTJpHdYC7Z2Ujpo3jVee2