### PR TITLE
Add location management feature with deduplication

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -48,14 +48,19 @@ func main() {
 		&model.Transaction{},
 		&model.Category{},
 		&model.Subcategory{},
+		&model.Location{},
 	); err != nil {
 		logger.Error("failed to auto migrate", "error", err)
 		os.Exit(1)
 	}
 
+	locationRepo := repository.NewLocationRepository(db)
+	locationService := service.NewLocationService(locationRepo)
+	locationHandler := handler.NewLocationHandler(locationService)
+
 	transactionRepo := repository.NewTransactionsRepository(db)
 	transactionService := service.NewTransactionsService(transactionRepo)
-	transactionHandler := handler.NewTransactionHandler(transactionService)
+	transactionHandler := handler.NewTransactionHandler(transactionService, locationService)
 
 	categoryRepo := repository.NewCategoryRepository(db)
 	categoryService := service.NewCategoryService(categoryRepo)
@@ -65,7 +70,7 @@ func main() {
 	subcategoryService := service.NewSubcategoryService(subcategoryRepo)
 	subcategoryHandler := handler.NewSubcategoryHandler(subcategoryService)
 
-	router := setupRouter(cfg, logger, transactionHandler, categoryHandler, subcategoryHandler)
+	router := setupRouter(cfg, logger, transactionHandler, categoryHandler, subcategoryHandler, locationHandler)
 
 	srv := &http.Server{
 		Addr:    fmt.Sprintf(":%s", cfg.Server.Port),
@@ -98,7 +103,7 @@ func main() {
 	logger.Info("server exited")
 }
 
-func setupRouter(cfg *config.Config, logger *slog.Logger, transactionHandler *handler.TransactionHandler, categoryHandler *handler.CategoryHandler, subcategoryHandler *handler.SubcategoryHandler) *gin.Engine {
+func setupRouter(cfg *config.Config, logger *slog.Logger, transactionHandler *handler.TransactionHandler, categoryHandler *handler.CategoryHandler, subcategoryHandler *handler.SubcategoryHandler, locationHandler *handler.LocationHandler) *gin.Engine {
 	if cfg.Log.Level != "debug" {
 		gin.SetMode(gin.ReleaseMode)
 	}
@@ -157,6 +162,16 @@ func setupRouter(cfg *config.Config, logger *slog.Logger, transactionHandler *ha
 			subcategories.GET("/:id", subcategoryHandler.GetSubcategoryByID)
 			subcategories.PUT("/:id", subcategoryHandler.UpdateSubcategory)
 			subcategories.DELETE("/:id", subcategoryHandler.DeleteSubcategory)
+		}
+
+		locations := v1.Group("/locations")
+		{
+			locations.GET("", locationHandler.GetLocations)
+			locations.POST("", locationHandler.CreateLocation)
+			locations.POST("/merge", locationHandler.MergeLocations)
+			locations.GET("/:id", locationHandler.GetLocationByID)
+			locations.PUT("/:id", locationHandler.UpdateLocation)
+			locations.DELETE("/:id", locationHandler.DeleteLocation)
 		}
 	}
 

--- a/internal/handler/location_handler.go
+++ b/internal/handler/location_handler.go
@@ -1,0 +1,187 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/ArthurWerle/transactions/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+type LocationHandler struct {
+	locationService service.LocationService
+}
+
+func NewLocationHandler(locationService service.LocationService) *LocationHandler {
+	return &LocationHandler{
+		locationService: locationService,
+	}
+}
+
+type CreateLocationRequest struct {
+	Name string `json:"name" binding:"required"`
+}
+
+func (h *LocationHandler) CreateLocation(c *gin.Context) {
+	var req CreateLocationRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "Invalid request body",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	location, err := h.locationService.FindOrCreate(c.Request.Context(), req.Name)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   "Failed to create location",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{
+		"message":  "Location created successfully",
+		"location": location,
+	})
+}
+
+func (h *LocationHandler) GetLocationByID(c *gin.Context) {
+	idParam := c.Param("id")
+	var id uint
+	if _, err := fmt.Sscanf(idParam, "%d", &id); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Invalid location ID",
+		})
+		return
+	}
+
+	location, err := h.locationService.GetLocationByID(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error":   "Location not found",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, location)
+}
+
+func (h *LocationHandler) GetLocations(c *gin.Context) {
+	locations, err := h.locationService.GetLocations(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   "Failed to fetch locations",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"locations": locations,
+		"count":     len(locations),
+	})
+}
+
+type UpdateLocationRequest struct {
+	Name *string `json:"name,omitempty"`
+}
+
+func (h *LocationHandler) UpdateLocation(c *gin.Context) {
+	idParam := c.Param("id")
+	var id uint
+	if _, err := fmt.Sscanf(idParam, "%d", &id); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Invalid location ID",
+		})
+		return
+	}
+
+	location, err := h.locationService.GetLocationByID(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error":   "Location not found",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	var req UpdateLocationRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "Invalid request body",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	if req.Name != nil {
+		location.Name = *req.Name
+	}
+
+	if err := h.locationService.UpdateLocation(c.Request.Context(), location); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   "Failed to update location",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message":  "Location updated successfully",
+		"location": location,
+	})
+}
+
+func (h *LocationHandler) DeleteLocation(c *gin.Context) {
+	idParam := c.Param("id")
+	var id uint
+	if _, err := fmt.Sscanf(idParam, "%d", &id); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Invalid location ID",
+		})
+		return
+	}
+
+	if err := h.locationService.DeleteLocation(c.Request.Context(), id); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   "Failed to delete location",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "Location deleted successfully",
+	})
+}
+
+type MergeLocationsRequest struct {
+	SourceID uint `json:"source_id" binding:"required"`
+	TargetID uint `json:"target_id" binding:"required"`
+}
+
+func (h *LocationHandler) MergeLocations(c *gin.Context) {
+	var req MergeLocationsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "Invalid request body",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	if err := h.locationService.MergeLocations(c.Request.Context(), req.SourceID, req.TargetID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   "Failed to merge locations",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "Locations merged successfully",
+	})
+}

--- a/internal/handler/transaction_handler.go
+++ b/internal/handler/transaction_handler.go
@@ -14,12 +14,36 @@ import (
 
 type TransactionHandler struct {
 	transactionService service.TransactionsService
+	locationService    service.LocationService
 }
 
-func NewTransactionHandler(transactionService service.TransactionsService) *TransactionHandler {
+func NewTransactionHandler(transactionService service.TransactionsService, locationService service.LocationService) *TransactionHandler {
 	return &TransactionHandler{
 		transactionService: transactionService,
+		locationService:    locationService,
 	}
+}
+
+// resolveLocation turns an optional free-text location name into a location_id.
+// A non-empty name is deduplicated via FindOrCreate; an explicitly empty string
+// clears the location. Returns (locationID, cleared, ok); ok is false when an
+// error response has already been written.
+func (h *TransactionHandler) resolveLocation(c *gin.Context, name *string) (*uint, bool, bool) {
+	if name == nil {
+		return nil, false, true
+	}
+	if strings.TrimSpace(*name) == "" {
+		return nil, true, true
+	}
+	location, err := h.locationService.FindOrCreate(c.Request.Context(), *name)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   "Failed to resolve location",
+			"details": err.Error(),
+		})
+		return nil, false, false
+	}
+	return &location.ID, false, true
 }
 
 type CreateTransactionRequest struct {
@@ -35,6 +59,7 @@ type CreateTransactionRequest struct {
 	Frequency   *string `json:"frequency,omitempty"`
 	StartDate   *string `json:"start_date,omitempty"`
 	EndDate     *string `json:"end_date,omitempty"`
+	Location    *string `json:"location,omitempty"`
 }
 
 func (h *TransactionHandler) CreateTransaction(c *gin.Context) {
@@ -113,6 +138,12 @@ func (h *TransactionHandler) CreateTransaction(c *gin.Context) {
 			return
 		}
 		transaction.EndDate = &parsedEndDate
+	}
+
+	if locationID, _, ok := h.resolveLocation(c, req.Location); ok {
+		transaction.LocationID = locationID
+	} else {
+		return
 	}
 
 	if err := h.transactionService.CreateTransaction(c.Request.Context(), transaction); err != nil {
@@ -421,6 +452,7 @@ type UpdateTransactionRequest struct {
 	Frequency   *string  `json:"frequency,omitempty"`
 	StartDate   *string  `json:"start_date,omitempty"`
 	EndDate     *string  `json:"end_date,omitempty"`
+	Location    *string  `json:"location,omitempty"`
 }
 
 func (h *TransactionHandler) UpdateTransaction(c *gin.Context) {
@@ -527,6 +559,16 @@ func (h *TransactionHandler) UpdateTransaction(c *gin.Context) {
 			return
 		}
 		transaction.EndDate = &parsedEndDate
+	}
+
+	if locationID, cleared, ok := h.resolveLocation(c, req.Location); ok {
+		if cleared {
+			transaction.LocationID = nil
+		} else if locationID != nil {
+			transaction.LocationID = locationID
+		}
+	} else {
+		return
 	}
 
 	if err := h.transactionService.UpdateTransaction(c.Request.Context(), transaction); err != nil {

--- a/internal/migrations/20260630_create_locations.sql
+++ b/internal/migrations/20260630_create_locations.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS locations (
+    id              SERIAL PRIMARY KEY,
+    name            VARCHAR(255) NOT NULL,
+    normalized_name VARCHAR(255) NOT NULL,
+    created_at      TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    deleted_at      TIMESTAMPTZ
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_locations_normalized_name ON locations(normalized_name) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_locations_deleted_at ON locations(deleted_at);
+
+ALTER TABLE transactions
+    ADD COLUMN IF NOT EXISTS location_id INTEGER;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE constraint_name = 'fk_location_id' AND table_name = 'transactions'
+    ) THEN
+        ALTER TABLE transactions
+            ADD CONSTRAINT fk_location_id
+            FOREIGN KEY (location_id) REFERENCES locations(id) ON DELETE SET NULL;
+    END IF;
+END $$;

--- a/internal/model/location.go
+++ b/internal/model/location.go
@@ -1,0 +1,20 @@
+package model
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type Location struct {
+	ID             uint           `gorm:"primaryKey;autoIncrement" json:"id"`
+	CreatedAt      time.Time      `gorm:"column:created_at" json:"created_at"`
+	UpdatedAt      time.Time      `gorm:"column:updated_at" json:"updated_at"`
+	DeletedAt      gorm.DeletedAt `gorm:"index" json:"deleted_at"`
+	Name           string         `gorm:"column:name;not null;size:255" json:"name"`
+	NormalizedName string         `gorm:"column:normalized_name;not null;size:255" json:"-"`
+}
+
+func (Location) TableName() string {
+	return "locations"
+}

--- a/internal/model/transactions.go
+++ b/internal/model/transactions.go
@@ -14,6 +14,8 @@ type Transaction struct {
 	CategoryID    *uint          `gorm:"column:category_id" json:"category_id"`
 	SubcategoryID *uint          `gorm:"column:subcategory_id" json:"subcategory_id"`
 	Subcategory   *Subcategory   `gorm:"foreignKey:SubcategoryID" json:"subcategory,omitempty"`
+	LocationID    *uint          `gorm:"column:location_id" json:"location_id"`
+	Location      *Location      `gorm:"foreignKey:LocationID" json:"location,omitempty"`
 	Amount        float64        `gorm:"type:decimal(12,2);not null" json:"amount"`
 	Type          string         `gorm:"type:transaction_type;not null" json:"type"`
 	Subtype       *string        `gorm:"type:transaction_subtype" json:"subtype"`

--- a/internal/repository/location_repository.go
+++ b/internal/repository/location_repository.go
@@ -1,0 +1,73 @@
+package repository
+
+import (
+	"github.com/ArthurWerle/transactions/internal/model"
+	"gorm.io/gorm"
+)
+
+type LocationRepository interface {
+	Create(location *model.Location) error
+	FindByID(id uint) (*model.Location, error)
+	FindByNormalizedName(normalizedName string) (*model.Location, error)
+	FindAll() ([]model.Location, error)
+	Update(location *model.Location) error
+	Delete(id uint) error
+	Merge(sourceID, targetID uint) error
+}
+
+type locationRepository struct {
+	db *gorm.DB
+}
+
+func NewLocationRepository(db *gorm.DB) LocationRepository {
+	return &locationRepository{db: db}
+}
+
+func (r *locationRepository) Create(location *model.Location) error {
+	return r.db.Create(location).Error
+}
+
+func (r *locationRepository) FindByID(id uint) (*model.Location, error) {
+	var location model.Location
+	err := r.db.First(&location, id).Error
+	if err != nil {
+		return nil, err
+	}
+	return &location, nil
+}
+
+func (r *locationRepository) FindByNormalizedName(normalizedName string) (*model.Location, error) {
+	var location model.Location
+	err := r.db.Where("normalized_name = ?", normalizedName).First(&location).Error
+	if err != nil {
+		return nil, err
+	}
+	return &location, nil
+}
+
+func (r *locationRepository) FindAll() ([]model.Location, error) {
+	var locations []model.Location
+	err := r.db.Order("name ASC").Find(&locations).Error
+	return locations, err
+}
+
+func (r *locationRepository) Update(location *model.Location) error {
+	return r.db.Save(location).Error
+}
+
+func (r *locationRepository) Delete(id uint) error {
+	return r.db.Delete(&model.Location{}, id).Error
+}
+
+// Merge reassigns every transaction pointing at sourceID to targetID, then soft-deletes
+// the now-empty source location. Used by the management UI to collapse duplicates.
+func (r *locationRepository) Merge(sourceID, targetID uint) error {
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&model.Transaction{}).
+			Where("location_id = ?", sourceID).
+			Update("location_id", targetID).Error; err != nil {
+			return err
+		}
+		return tx.Delete(&model.Location{}, sourceID).Error
+	})
+}

--- a/internal/repository/transactions_repository.go
+++ b/internal/repository/transactions_repository.go
@@ -85,7 +85,7 @@ func (r *transactionsRepository) Create(transaction *model.Transaction) error {
 
 func (r *transactionsRepository) FindByID(id uint) (*model.Transaction, error) {
 	var transaction model.Transaction
-	err := r.db.Scopes(WithIsPrepaid).Preload("Subcategory").First(&transaction, id).Error
+	err := r.db.Scopes(WithIsPrepaid).Preload("Subcategory").Preload("Location").First(&transaction, id).Error
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +94,7 @@ func (r *transactionsRepository) FindByID(id uint) (*model.Transaction, error) {
 
 func (r *transactionsRepository) FindByPrepaidID(prepaidID uint) (*model.Transaction, error) {
 	var transaction model.Transaction
-	err := r.db.Scopes(WithIsPrepaid).Preload("Subcategory").Where("prepaid_from_id = ?", prepaidID).First(&transaction).Error
+	err := r.db.Scopes(WithIsPrepaid).Preload("Subcategory").Preload("Location").Where("prepaid_from_id = ?", prepaidID).First(&transaction).Error
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (r *transactionsRepository) FindByPrepaidID(prepaidID uint) (*model.Transac
 
 func (r *transactionsRepository) FindAll(limit, offset int) ([]model.Transaction, error) {
 	var transactions []model.Transaction
-	err := r.db.Scopes(WithIsPrepaid).Preload("Subcategory").Order("is_recurring, date DESC").Limit(limit).Offset(offset).Find(&transactions).Error
+	err := r.db.Scopes(WithIsPrepaid).Preload("Subcategory").Preload("Location").Order("is_recurring, date DESC").Limit(limit).Offset(offset).Find(&transactions).Error
 	return transactions, err
 }
 
@@ -155,7 +155,7 @@ func (r *transactionsRepository) buildFilterQuery(currentMonth bool, categoryIDs
 func (r *transactionsRepository) FindAllWithFilters(currentMonth bool, categoryIDs []uint, searchQuery string, startDate, endDate *time.Time, transactionType string, limit, offset int) ([]model.Transaction, error) {
 	var transactions []model.Transaction
 	query := r.buildFilterQuery(currentMonth, categoryIDs, searchQuery, startDate, endDate, transactionType).Scopes(WithIsPrepaid)
-	err := query.Preload("Subcategory").Order("is_recurring, date DESC").Limit(limit).Offset(offset).Find(&transactions).Error
+	err := query.Preload("Subcategory").Preload("Location").Order("is_recurring, date DESC").Limit(limit).Offset(offset).Find(&transactions).Error
 	return transactions, err
 }
 
@@ -167,7 +167,7 @@ func (r *transactionsRepository) CountAllWithFilters(currentMonth bool, category
 
 func (r *transactionsRepository) FindLatest() ([]model.Transaction, error) {
 	var transactions []model.Transaction
-	err := r.db.Model(&model.Transaction{}).Scopes(WithIsPrepaid).Preload("Subcategory").Where("date IS NOT NULL AND type = ?", model.Expense).Order("date DESC").Limit(3).Find(&transactions).Error
+	err := r.db.Model(&model.Transaction{}).Scopes(WithIsPrepaid).Preload("Subcategory").Preload("Location").Where("date IS NOT NULL AND type = ?", model.Expense).Order("date DESC").Limit(3).Find(&transactions).Error
 	return transactions, err
 }
 
@@ -175,7 +175,7 @@ func (r *transactionsRepository) FindBiggest(month, year int) ([]model.Transacti
 	var transactions []model.Transaction
 	startOfMonth := time.Date(year, time.Month(month), 1, 0, 0, 0, 0, time.UTC)
 	endOfMonth := startOfMonth.AddDate(0, 1, 0).Add(-time.Second)
-	err := r.db.Model(&model.Transaction{}).Scopes(WithIsPrepaid).Preload("Subcategory").Where(
+	err := r.db.Model(&model.Transaction{}).Scopes(WithIsPrepaid).Preload("Subcategory").Preload("Location").Where(
 		"type = ? AND ((is_recurring = false AND date >= ? AND date <= ?) OR (is_recurring = true AND start_date <= ? AND (end_date >= ? OR end_date IS NULL)))",
 		model.Expense, startOfMonth, endOfMonth, endOfMonth, startOfMonth,
 	).Order("amount DESC").Limit(3).Find(&transactions).Error
@@ -194,7 +194,7 @@ func (r *transactionsRepository) FindByDateRange(startDate, endDate time.Time) (
 	var transactions []model.Transaction
 	endOfDay := time.Date(endDate.Year(), endDate.Month(), endDate.Day()+1, 0, 0, 0, 0, endDate.Location())
 	log.Printf("FindByDateRange: startDate=%s endDate=%s endOfDay=%s", startDate.Format(time.RFC3339), endDate.Format(time.RFC3339), endOfDay.Format(time.RFC3339))
-	err := r.db.Scopes(WithIsPrepaid).Preload("Subcategory").Where(
+	err := r.db.Scopes(WithIsPrepaid).Preload("Subcategory").Preload("Location").Where(
 		"(is_recurring = ? AND date >= ? AND date < ?) OR (is_recurring = ? AND start_date < ? AND (end_date >= ? OR end_date IS NULL))",
 		false, startDate, endOfDay,
 		true, endOfDay, startDate,
@@ -206,7 +206,7 @@ func (r *transactionsRepository) FindByDateRange(startDate, endDate time.Time) (
 
 func (r *transactionsRepository) FindByType(transactionType string, limit, offset int) ([]model.Transaction, error) {
 	var transactions []model.Transaction
-	err := r.db.Scopes(WithIsPrepaid).Preload("Subcategory").Where("type = ?", transactionType).
+	err := r.db.Scopes(WithIsPrepaid).Preload("Subcategory").Preload("Location").Where("type = ?", transactionType).
 		Limit(limit).
 		Offset(offset).
 		Order("date DESC").
@@ -216,7 +216,7 @@ func (r *transactionsRepository) FindByType(transactionType string, limit, offse
 
 func (r *transactionsRepository) FindRecurring() ([]model.Transaction, error) {
 	var transactions []model.Transaction
-	err := r.db.Scopes(WithIsPrepaid).Preload("Subcategory").Where("is_recurring = ?", true).
+	err := r.db.Scopes(WithIsPrepaid).Preload("Subcategory").Preload("Location").Where("is_recurring = ?", true).
 		Order("start_date DESC").
 		Find(&transactions).Error
 	return transactions, err
@@ -224,7 +224,7 @@ func (r *transactionsRepository) FindRecurring() ([]model.Transaction, error) {
 
 func (r *transactionsRepository) FindByCategory(categoryID uint, limit, offset int) ([]model.Transaction, error) {
 	var transactions []model.Transaction
-	err := r.db.Scopes(WithIsPrepaid).Preload("Subcategory").Where("category_id = ?", categoryID).
+	err := r.db.Scopes(WithIsPrepaid).Preload("Subcategory").Preload("Location").Where("category_id = ?", categoryID).
 		Limit(limit).
 		Offset(offset).
 		Order("date DESC").
@@ -239,7 +239,7 @@ func (r *transactionsRepository) FindByCategories(categoriesIDs []uint, limit, o
 		return transactions, nil
 	}
 
-	err := r.db.Scopes(WithIsPrepaid).Preload("Subcategory").Where("category_id in ?", categoriesIDs).
+	err := r.db.Scopes(WithIsPrepaid).Preload("Subcategory").Preload("Location").Where("category_id in ?", categoriesIDs).
 		Limit(limit).
 		Offset(offset).
 		Order("date DESC").

--- a/internal/service/location_service.go
+++ b/internal/service/location_service.go
@@ -1,0 +1,86 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/ArthurWerle/transactions/internal/model"
+	"github.com/ArthurWerle/transactions/internal/repository"
+	"gorm.io/gorm"
+)
+
+type LocationService interface {
+	FindOrCreate(ctx context.Context, name string) (*model.Location, error)
+	GetLocationByID(ctx context.Context, id uint) (*model.Location, error)
+	GetLocations(ctx context.Context) ([]model.Location, error)
+	UpdateLocation(ctx context.Context, location *model.Location) error
+	DeleteLocation(ctx context.Context, id uint) error
+	MergeLocations(ctx context.Context, sourceID, targetID uint) error
+}
+
+type locationService struct {
+	locationRepo repository.LocationRepository
+}
+
+func NewLocationService(locationRepo repository.LocationRepository) LocationService {
+	return &locationService{
+		locationRepo: locationRepo,
+	}
+}
+
+// normalizeLocationName collapses casing and whitespace so that "Mercado X",
+// "mercado x " and "MERCADO  X" all resolve to the same dedup key.
+func normalizeLocationName(name string) string {
+	return strings.ToLower(strings.Join(strings.Fields(name), " "))
+}
+
+// FindOrCreate returns the existing location matching the normalized name, or
+// creates a new one keeping the caller's original casing as the display name.
+func (s *locationService) FindOrCreate(ctx context.Context, name string) (*model.Location, error) {
+	normalized := normalizeLocationName(name)
+	if normalized == "" {
+		return nil, errors.New("location name cannot be empty")
+	}
+
+	existing, err := s.locationRepo.FindByNormalizedName(normalized)
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+	if existing != nil {
+		return existing, nil
+	}
+
+	location := &model.Location{
+		Name:           strings.TrimSpace(name),
+		NormalizedName: normalized,
+	}
+	if err := s.locationRepo.Create(location); err != nil {
+		return nil, err
+	}
+	return location, nil
+}
+
+func (s *locationService) GetLocationByID(ctx context.Context, id uint) (*model.Location, error) {
+	return s.locationRepo.FindByID(id)
+}
+
+func (s *locationService) GetLocations(ctx context.Context) ([]model.Location, error) {
+	return s.locationRepo.FindAll()
+}
+
+func (s *locationService) UpdateLocation(ctx context.Context, location *model.Location) error {
+	location.NormalizedName = normalizeLocationName(location.Name)
+	return s.locationRepo.Update(location)
+}
+
+func (s *locationService) DeleteLocation(ctx context.Context, id uint) error {
+	return s.locationRepo.Delete(id)
+}
+
+func (s *locationService) MergeLocations(ctx context.Context, sourceID, targetID uint) error {
+	if sourceID == targetID {
+		return errors.New("source and target locations must be different")
+	}
+	return s.locationRepo.Merge(sourceID, targetID)
+}

--- a/internal/service/location_service_test.go
+++ b/internal/service/location_service_test.go
@@ -1,0 +1,149 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ArthurWerle/transactions/internal/model"
+	"gorm.io/gorm"
+)
+
+type mockLocationRepository struct {
+	locations    map[uint]*model.Location
+	mergedSource uint
+	mergedTarget uint
+}
+
+func newMockLocationRepository() *mockLocationRepository {
+	return &mockLocationRepository{locations: make(map[uint]*model.Location)}
+}
+
+func (m *mockLocationRepository) Create(location *model.Location) error {
+	if location.ID == 0 {
+		location.ID = uint(len(m.locations) + 1)
+	}
+	m.locations[location.ID] = location
+	return nil
+}
+
+func (m *mockLocationRepository) FindByID(id uint) (*model.Location, error) {
+	l, ok := m.locations[id]
+	if !ok {
+		return nil, gorm.ErrRecordNotFound
+	}
+	return l, nil
+}
+
+func (m *mockLocationRepository) FindByNormalizedName(normalizedName string) (*model.Location, error) {
+	for _, l := range m.locations {
+		if l.NormalizedName == normalizedName {
+			return l, nil
+		}
+	}
+	return nil, gorm.ErrRecordNotFound
+}
+
+func (m *mockLocationRepository) FindAll() ([]model.Location, error) {
+	var out []model.Location
+	for _, l := range m.locations {
+		out = append(out, *l)
+	}
+	return out, nil
+}
+
+func (m *mockLocationRepository) Update(location *model.Location) error {
+	m.locations[location.ID] = location
+	return nil
+}
+
+func (m *mockLocationRepository) Delete(id uint) error {
+	delete(m.locations, id)
+	return nil
+}
+
+func (m *mockLocationRepository) Merge(sourceID, targetID uint) error {
+	m.mergedSource = sourceID
+	m.mergedTarget = targetID
+	delete(m.locations, sourceID)
+	return nil
+}
+
+func TestFindOrCreate_DeduplicatesByNormalizedName(t *testing.T) {
+	repo := newMockLocationRepository()
+	svc := NewLocationService(repo)
+	ctx := context.Background()
+
+	first, err := svc.FindOrCreate(ctx, "Mercado X")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Casing and extra whitespace must resolve to the same record.
+	for _, variant := range []string{"mercado x ", "MERCADO  X", "  Mercado X  "} {
+		got, err := svc.FindOrCreate(ctx, variant)
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", variant, err)
+		}
+		if got.ID != first.ID {
+			t.Errorf("variant %q created a new location (id=%d), expected reuse of id=%d", variant, got.ID, first.ID)
+		}
+	}
+
+	if len(repo.locations) != 1 {
+		t.Errorf("expected 1 location stored, got %d", len(repo.locations))
+	}
+
+	// The display name keeps the original casing of the first insertion.
+	if first.Name != "Mercado X" {
+		t.Errorf("expected display name 'Mercado X', got %q", first.Name)
+	}
+}
+
+func TestFindOrCreate_CreatesDistinctNames(t *testing.T) {
+	repo := newMockLocationRepository()
+	svc := NewLocationService(repo)
+	ctx := context.Background()
+
+	a, _ := svc.FindOrCreate(ctx, "Mercado X")
+	b, _ := svc.FindOrCreate(ctx, "Lancheria Y")
+
+	if a.ID == b.ID {
+		t.Errorf("distinct names should produce distinct locations, both got id=%d", a.ID)
+	}
+	if len(repo.locations) != 2 {
+		t.Errorf("expected 2 locations stored, got %d", len(repo.locations))
+	}
+}
+
+func TestFindOrCreate_RejectsEmptyName(t *testing.T) {
+	svc := NewLocationService(newMockLocationRepository())
+	if _, err := svc.FindOrCreate(context.Background(), "   "); err == nil {
+		t.Error("expected error for blank location name, got nil")
+	}
+}
+
+func TestMergeLocations(t *testing.T) {
+	repo := newMockLocationRepository()
+	svc := NewLocationService(repo)
+	ctx := context.Background()
+
+	source, _ := svc.FindOrCreate(ctx, "mercdo x")
+	target, _ := svc.FindOrCreate(ctx, "Mercado X")
+
+	if err := svc.MergeLocations(ctx, source.ID, target.ID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.mergedSource != source.ID || repo.mergedTarget != target.ID {
+		t.Errorf("merge called with (%d,%d), expected (%d,%d)", repo.mergedSource, repo.mergedTarget, source.ID, target.ID)
+	}
+	if _, ok := repo.locations[source.ID]; ok {
+		t.Error("source location should have been removed after merge")
+	}
+}
+
+func TestMergeLocations_RejectsSameSourceAndTarget(t *testing.T) {
+	svc := NewLocationService(newMockLocationRepository())
+	if err := svc.MergeLocations(context.Background(), 1, 1); err == nil {
+		t.Error("expected error when merging a location into itself, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
This PR introduces a complete location management system for transactions, including CRUD operations, intelligent deduplication by normalized names, and a merge capability for consolidating duplicate locations.

## Key Changes

- **New Location Model & Repository**: Added `Location` model with `name` and `normalized_name` fields for deduplication. Implemented `LocationRepository` with full CRUD operations plus a `Merge` method that reassigns transactions and soft-deletes source locations.

- **Location Service**: Created `LocationService` with:
  - `FindOrCreate`: Deduplicates locations by normalized name (case-insensitive, whitespace-collapsed) while preserving original casing as display name
  - Standard CRUD operations
  - `MergeLocations`: Consolidates duplicate locations in a transaction, preventing self-merges

- **Location Handler**: Added HTTP endpoints for:
  - `POST /locations` - Create or find existing location
  - `GET /locations` - List all locations with count
  - `GET /locations/:id` - Retrieve specific location
  - `PUT /locations/:id` - Update location name
  - `DELETE /locations/:id` - Delete location
  - `POST /locations/merge` - Merge two locations

- **Transaction Integration**: 
  - Extended `Transaction` model with optional `LocationID` foreign key
  - Updated `TransactionHandler` to accept optional `location` field in create/update requests
  - Added `resolveLocation` helper to handle location name resolution with deduplication
  - Updated transaction repository queries to preload location data

- **Database Migration**: Created migration to add `locations` table with unique constraint on normalized names and foreign key relationship to transactions.

## Notable Implementation Details

- Location names are normalized by converting to lowercase and collapsing whitespace, enabling "Mercado X", "mercado x ", and "MERCADO  X" to resolve to the same record
- The merge operation uses a database transaction to atomically reassign all transactions and delete the source location
- Locations support soft-delete via `deleted_at` timestamp
- Comprehensive test coverage for deduplication, distinct names, empty name rejection, and merge validation

https://claude.ai/code/session_01J1TnrcXXAFbb8TuGnBLNPx