### PR TITLE
Change default transaction origin from 'api' to 'web'

### DIFF
--- a/internal/handler/transaction_handler.go
+++ b/internal/handler/transaction_handler.go
@@ -97,7 +97,7 @@ func (h *TransactionHandler) CreateTransaction(c *gin.Context) {
 
 	validOrigins := map[string]bool{"web": true, "api": true, "mcp": true}
 	if req.Origin == "" || !validOrigins[req.Origin] {
-		req.Origin = "api"
+		req.Origin = "web"
 	}
 
 	transaction := &model.Transaction{

--- a/internal/migrations/20260701_add_transaction_origin.sql
+++ b/internal/migrations/20260701_add_transaction_origin.sql
@@ -9,6 +9,6 @@ DO $$
 $$;
 
 ALTER TABLE transactions
-    ADD COLUMN IF NOT EXISTS origin transaction_origin NOT NULL DEFAULT 'api';
+    ADD COLUMN IF NOT EXISTS origin transaction_origin NOT NULL DEFAULT 'web';
 
 COMMENT ON COLUMN transactions.subtype IS 'Deprecated: do not use. Will be removed in a future migration.';

--- a/internal/model/transactions.go
+++ b/internal/model/transactions.go
@@ -20,7 +20,7 @@ type Transaction struct {
 	Type          string         `gorm:"type:transaction_type;not null" json:"type"`
 	// Deprecated: Subtype will be removed. Do not use.
 	Subtype       *string        `gorm:"type:transaction_subtype" json:"subtype,omitempty"`
-	Origin        string         `gorm:"type:transaction_origin;not null;default:api" json:"origin"`
+	Origin        string         `gorm:"type:transaction_origin;not null;default:web" json:"origin"`
 	Description   *string        `gorm:"type:text" json:"description"`
 	Date          *time.Time     `gorm:"type:timestamptz" json:"date"`
 	Frequency     *string        `gorm:"type:varchar(50)" json:"frequency"`


### PR DESCRIPTION
## Summary
This PR updates the default origin value for transactions from 'api' to 'web' across the codebase, ensuring consistency in how transactions are categorized when no explicit origin is provided.

## Key Changes
- Updated the default origin fallback in `TransactionHandler.CreateTransaction()` from 'api' to 'web'
- Modified the database migration to set the default column value to 'web' instead of 'api'
- Updated the Transaction model struct tag to reflect the new default value of 'web'

## Implementation Details
All three locations that define or enforce the default transaction origin have been updated consistently:
1. **Handler logic**: When a request has no origin or an invalid origin, it now defaults to 'web'
2. **Database schema**: The `origin` column default constraint now uses 'web'
3. **Model definition**: The GORM struct tag reflects the updated default

This ensures that transactions created without an explicit origin will be marked as 'web' origin by default, which better represents the primary user-facing interface for transaction creation.

https://claude.ai/code/session_011yJckVcSw3B6mdtE4xxZ4n