### PR TITLE
Enforce transaction shape invariant and add timezone-aware reporting

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"syscall"
 	"time"
+	_ "time/tzdata"
 
 	"github.com/ArthurWerle/transactions/internal/config"
 	"github.com/ArthurWerle/transactions/internal/handler"
@@ -54,13 +55,19 @@ func main() {
 		os.Exit(1)
 	}
 
+	reportingLoc, err := time.LoadLocation(cfg.Reporting.Timezone)
+	if err != nil {
+		logger.Error("invalid REPORTING_TIMEZONE", "timezone", cfg.Reporting.Timezone, "error", err)
+		os.Exit(1)
+	}
+
 	locationRepo := repository.NewLocationRepository(db)
 	locationService := service.NewLocationService(locationRepo)
 	locationHandler := handler.NewLocationHandler(locationService)
 
-	transactionRepo := repository.NewTransactionsRepository(db)
-	transactionService := service.NewTransactionsService(transactionRepo)
-	transactionHandler := handler.NewTransactionHandler(transactionService, locationService)
+	transactionRepo := repository.NewTransactionsRepository(db, reportingLoc)
+	transactionService := service.NewTransactionsService(transactionRepo, reportingLoc)
+	transactionHandler := handler.NewTransactionHandler(transactionService, locationService, reportingLoc)
 
 	categoryRepo := repository.NewCategoryRepository(db)
 	categoryService := service.NewCategoryService(categoryRepo)
@@ -138,7 +145,6 @@ func setupRouter(cfg *config.Config, logger *slog.Logger, transactionHandler *ha
 			transactions.POST("/:id/prepay", transactionHandler.PrepayTransaction)
 			transactions.PATCH("/:id/end", transactionHandler.EndRecurringTransaction)
 			transactions.POST("/by-categories", transactionHandler.GetTransactionsByCategories)
-			transactions.POST("/by-category/:id", transactionHandler.GetTransactionsByCategory)
 			transactions.POST("/by-date-range", transactionHandler.GetTransactionsByDateRange)
 			transactions.GET("/latest", transactionHandler.GetLatestTransactions)
 			transactions.GET("/biggest", transactionHandler.GetBiggestTransactions)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,9 +6,16 @@ import (
 )
 
 type Config struct {
-	Server   ServerConfig
-	Database DatabaseConfig
-	Log      LogConfig
+	Server    ServerConfig
+	Database  DatabaseConfig
+	Log       LogConfig
+	Reporting ReportingConfig
+}
+
+type ReportingConfig struct {
+	// Timezone defines the calendar used for all month/day bucketing in
+	// reports (e.g. which month a late-night transaction belongs to).
+	Timezone string
 }
 
 type ServerConfig struct {
@@ -43,6 +50,9 @@ func Load() (*Config, error) {
 		},
 		Log: LogConfig{
 			Level: getEnv("LOG_LEVEL", "info"),
+		},
+		Reporting: ReportingConfig{
+			Timezone: getEnv("REPORTING_TIMEZONE", "America/Sao_Paulo"),
 		},
 	}
 

--- a/internal/handler/transaction_handler.go
+++ b/internal/handler/transaction_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -15,13 +16,28 @@ import (
 type TransactionHandler struct {
 	transactionService service.TransactionsService
 	locationService    service.LocationService
+	loc                *time.Location
 }
 
-func NewTransactionHandler(transactionService service.TransactionsService, locationService service.LocationService) *TransactionHandler {
+func NewTransactionHandler(transactionService service.TransactionsService, locationService service.LocationService, loc *time.Location) *TransactionHandler {
 	return &TransactionHandler{
 		transactionService: transactionService,
 		locationService:    locationService,
+		loc:                loc,
 	}
+}
+
+// respondTransactionError maps service validation errors to 400 and
+// everything else to 500.
+func respondTransactionError(c *gin.Context, err error, message string) {
+	status := http.StatusInternalServerError
+	if errors.Is(err, service.ErrInvalidTransaction) {
+		status = http.StatusBadRequest
+	}
+	c.JSON(status, gin.H{
+		"error":   message,
+		"details": err.Error(),
+	})
 }
 
 // resolveLocation turns an optional free-text location name into a location_id.
@@ -155,10 +171,7 @@ func (h *TransactionHandler) CreateTransaction(c *gin.Context) {
 	}
 
 	if err := h.transactionService.CreateTransaction(c.Request.Context(), transaction); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "Failed to create transaction",
-			"details": err.Error(),
-		})
+		respondTransactionError(c, err, "Failed to create transaction")
 		return
 	}
 
@@ -176,54 +189,58 @@ type TransactionDetailResponse struct {
 	TotalMonthPercent    *float64 `json:"total_month_percent,omitempty"`
 }
 
-func computeTotalPaid(tx *model.Transaction) *float64 {
+// computeTotalPaid returns how much of a recurring schedule has been paid so
+// far. The current month counts as paid — the same convention prepay uses —
+// so computeTotalPaid + computeTotalLeft always covers the whole schedule.
+func computeTotalPaid(tx *model.Transaction, now time.Time) *float64 {
 	if !tx.IsRecurring || tx.StartDate == nil {
 		return nil
 	}
 
-	now := time.Now()
-	startDate := time.Date(tx.StartDate.Year(), tx.StartDate.Month(), 1, 0, 0, 0, 0, time.UTC)
-	effectiveEnd := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
-
-	if tx.EndDate != nil {
-		endDate := time.Date(tx.EndDate.Year(), tx.EndDate.Month(), 1, 0, 0, 0, 0, time.UTC)
-		if endDate.Before(effectiveEnd) {
-			effectiveEnd = endDate
-		}
-	}
-
-	if effectiveEnd.Before(startDate) {
-		return nil
-	}
-
-	years := effectiveEnd.Year() - startDate.Year()
-	months := int(effectiveEnd.Month()) - int(startDate.Month())
-	monthsPaid := years*12 + months
-
-	total := tx.Amount * float64(monthsPaid)
-	return &total
-}
-
-func computeTotalLeft(tx *model.Transaction) *float64 {
-	if !tx.IsRecurring || tx.StartDate == nil || tx.EndDate == nil {
-		return nil
-	}
-
-	now := time.Now()
-	effectiveStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
-	endDate := time.Date(tx.EndDate.Year(), tx.EndDate.Month(), 1, 0, 0, 0, 0, time.UTC)
-
-	if endDate.Before(effectiveStart) {
+	startMonth := service.MonthStart(*tx.StartDate)
+	currentMonth := service.MonthStart(now)
+	if startMonth.After(currentMonth) {
 		zero := 0.0
 		return &zero
 	}
 
-	years := endDate.Year() - effectiveStart.Year()
-	months := int(endDate.Month()) - int(effectiveStart.Month())
-	monthsLeft := years*12 + months
+	effectiveEnd := currentMonth
+	if tx.EndDate != nil {
+		if e := service.MonthStart(*tx.EndDate); e.Before(effectiveEnd) {
+			effectiveEnd = e
+		}
+	}
 
-	total := tx.Amount * float64(monthsLeft)
+	total := tx.Amount * float64(service.InclusiveMonthCount(startMonth, effectiveEnd))
 	return &total
+}
+
+func computeTotalLeft(tx *model.Transaction, now time.Time) *float64 {
+	if !tx.IsRecurring || tx.StartDate == nil || tx.EndDate == nil {
+		return nil
+	}
+
+	startMonth := service.MonthStart(*tx.StartDate)
+	endMonth := service.MonthStart(*tx.EndDate)
+	currentMonth := service.MonthStart(now)
+
+	if endMonth.Before(startMonth) {
+		zero := 0.0
+		return &zero
+	}
+
+	totalMonths := service.InclusiveMonthCount(startMonth, endMonth)
+	paidMonths := 0
+	if !startMonth.After(currentMonth) {
+		effectiveEnd := currentMonth
+		if endMonth.Before(effectiveEnd) {
+			effectiveEnd = endMonth
+		}
+		paidMonths = service.InclusiveMonthCount(startMonth, effectiveEnd)
+	}
+
+	left := tx.Amount * float64(totalMonths-paidMonths)
+	return &left
 }
 
 func (h *TransactionHandler) GetTransactionByID(c *gin.Context) {
@@ -254,10 +271,11 @@ func (h *TransactionHandler) GetTransactionByID(c *gin.Context) {
 		return
 	}
 
+	now := time.Now().In(h.loc)
 	resp := TransactionDetailResponse{
 		Transaction: transaction,
-		TotalPaid:   computeTotalPaid(transaction),
-		TotalLeft:   computeTotalLeft(transaction),
+		TotalPaid:   computeTotalPaid(transaction, now),
+		TotalLeft:   computeTotalLeft(transaction, now),
 	}
 	if percentages != nil {
 		resp.CategoryMonthPercent = percentages.CategoryMonthPercent
@@ -308,7 +326,7 @@ func (h *TransactionHandler) GetTransactions(c *gin.Context) {
 
 	var startDate, endDate *time.Time
 	if s := c.Query("start_date"); s != "" {
-		parsed, err := time.Parse("2006-01-02", s)
+		parsed, err := time.ParseInLocation("2006-01-02", s, h.loc)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error":   "Invalid start_date format",
@@ -319,7 +337,7 @@ func (h *TransactionHandler) GetTransactions(c *gin.Context) {
 		startDate = &parsed
 	}
 	if s := c.Query("end_date"); s != "" {
-		parsed, err := time.Parse("2006-01-02", s)
+		parsed, err := time.ParseInLocation("2006-01-02", s, h.loc)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error":   "Invalid end_date format",
@@ -327,7 +345,10 @@ func (h *TransactionHandler) GetTransactions(c *gin.Context) {
 			})
 			return
 		}
-		endDate = &parsed
+		// The query param names an inclusive calendar day; the repository
+		// works with half-open intervals.
+		exclusive := parsed.AddDate(0, 0, 1)
+		endDate = &exclusive
 	}
 
 	limit := 50
@@ -353,12 +374,13 @@ func (h *TransactionHandler) GetTransactions(c *gin.Context) {
 
 	var transactions []model.Transaction
 	var total int64
+	var sum float64
 	var err error
 
 	if currentMonth || len(categoryIDs) > 0 || searchQuery != "" || startDate != nil || endDate != nil || transactionType != "" {
-		transactions, total, err = h.transactionService.GetTransactionsWithFilters(c.Request.Context(), currentMonth, categoryIDs, searchQuery, startDate, endDate, transactionType, limit, offset)
+		transactions, total, sum, err = h.transactionService.GetTransactionsWithFilters(c.Request.Context(), currentMonth, categoryIDs, searchQuery, startDate, endDate, transactionType, limit, offset)
 	} else {
-		transactions, total, err = h.transactionService.GetTransactions(c.Request.Context(), limit, offset)
+		transactions, total, sum, err = h.transactionService.GetTransactions(c.Request.Context(), limit, offset)
 	}
 
 	if err != nil {
@@ -367,11 +389,6 @@ func (h *TransactionHandler) GetTransactions(c *gin.Context) {
 			"details": err.Error(),
 		})
 		return
-	}
-
-	var sum float64
-	for _, t := range transactions {
-		sum += t.Amount
 	}
 
 	c.JSON(http.StatusOK, gin.H{
@@ -405,7 +422,7 @@ func (h *TransactionHandler) GetLatestTransactions(c *gin.Context) {
 }
 
 func (h *TransactionHandler) GetBiggestTransactions(c *gin.Context) {
-	now := time.Now()
+	now := time.Now().In(h.loc)
 	month := int(now.Month())
 	year := now.Year()
 
@@ -578,10 +595,7 @@ func (h *TransactionHandler) UpdateTransaction(c *gin.Context) {
 	}
 
 	if err := h.transactionService.UpdateTransaction(c.Request.Context(), transaction); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "Failed to update transaction",
-			"details": err.Error(),
-		})
+		respondTransactionError(c, err, "Failed to update transaction")
 		return
 	}
 
@@ -646,13 +660,18 @@ func (h *TransactionHandler) EndRecurringTransaction(c *gin.Context) {
 		return
 	}
 
+	if transaction.StartDate != nil && parsedEndDate.Before(*transaction.StartDate) {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "Invalid end_date",
+			"details": "end_date must not be before start_date",
+		})
+		return
+	}
+
 	transaction.EndDate = &parsedEndDate
 
 	if err := h.transactionService.UpdateTransaction(c.Request.Context(), transaction); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "Failed to end recurring transaction",
-			"details": err.Error(),
-		})
+		respondTransactionError(c, err, "Failed to end recurring transaction")
 		return
 	}
 
@@ -696,7 +715,7 @@ func (h *TransactionHandler) GetTransactionsByDateRange(c *gin.Context) {
 		return
 	}
 
-	startDate, err := time.Parse("2006-01-02", startDateStr)
+	startDate, err := time.ParseInLocation("2006-01-02", startDateStr, h.loc)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error":   "Invalid start_date format",
@@ -705,7 +724,7 @@ func (h *TransactionHandler) GetTransactionsByDateRange(c *gin.Context) {
 		return
 	}
 
-	endDate, err := time.Parse("2006-01-02", endDateStr)
+	endDate, err := time.ParseInLocation("2006-01-02", endDateStr, h.loc)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error":   "Invalid end_date format",
@@ -714,7 +733,9 @@ func (h *TransactionHandler) GetTransactionsByDateRange(c *gin.Context) {
 		return
 	}
 
-	transactions, err := h.transactionService.GetTransactionsByDateRange(c.Request.Context(), startDate, endDate)
+	// end_date names an inclusive calendar day; the repository works with
+	// half-open intervals.
+	transactions, err := h.transactionService.GetTransactionsByDateRange(c.Request.Context(), startDate, endDate.AddDate(0, 0, 1))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error":   "Failed to fetch transactions",
@@ -728,133 +749,6 @@ func (h *TransactionHandler) GetTransactionsByDateRange(c *gin.Context) {
 		"count":        len(transactions),
 		"start_date":   startDateStr,
 		"end_date":     endDateStr,
-	})
-}
-
-func (h *TransactionHandler) GetTransactionsByType(c *gin.Context) {
-	transactionType := c.Query("type")
-	if transactionType == "" {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "Type query parameter is required",
-		})
-		return
-	}
-
-	// Validate type
-	validTypes := map[string]bool{
-		"income":  true,
-		"expense": true,
-	}
-	if !validTypes[transactionType] {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "Type must be either 'income' or 'expense'",
-		})
-		return
-	}
-
-	// Parse pagination parameters
-	limit := 50 // default
-	offset := 0 // default
-
-	if limitStr := c.Query("limit"); limitStr != "" {
-		if _, err := fmt.Sscanf(limitStr, "%d", &limit); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error": "Invalid limit parameter",
-			})
-			return
-		}
-	}
-
-	if offsetStr := c.Query("offset"); offsetStr != "" {
-		if _, err := fmt.Sscanf(offsetStr, "%d", &offset); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error": "Invalid offset parameter",
-			})
-			return
-		}
-	}
-
-	transactions, err := h.transactionService.GetTransactionsByType(c.Request.Context(), transactionType, limit, offset)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "Failed to fetch transactions",
-			"details": err.Error(),
-		})
-		return
-	}
-
-	c.JSON(http.StatusOK, gin.H{
-		"transactions": transactions,
-		"count":        len(transactions),
-		"type":         transactionType,
-		"limit":        limit,
-		"offset":       offset,
-	})
-}
-
-func (h *TransactionHandler) GetRecurringTransactions(c *gin.Context) {
-	transactions, err := h.transactionService.GetRecurringTransactions(c.Request.Context())
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "Failed to fetch recurring transactions",
-			"details": err.Error(),
-		})
-		return
-	}
-
-	c.JSON(http.StatusOK, gin.H{
-		"transactions": transactions,
-		"count":        len(transactions),
-	})
-}
-
-func (h *TransactionHandler) GetTransactionsByCategory(c *gin.Context) {
-	categoryIDParam := c.Param("categoryId")
-	var categoryID uint
-	if _, err := fmt.Sscanf(categoryIDParam, "%d", &categoryID); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "Invalid category ID",
-		})
-		return
-	}
-
-	// Parse pagination parameters
-	limit := 50 // default
-	offset := 0 // default
-
-	if limitStr := c.Query("limit"); limitStr != "" {
-		if _, err := fmt.Sscanf(limitStr, "%d", &limit); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error": "Invalid limit parameter",
-			})
-			return
-		}
-	}
-
-	if offsetStr := c.Query("offset"); offsetStr != "" {
-		if _, err := fmt.Sscanf(offsetStr, "%d", &offset); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error": "Invalid offset parameter",
-			})
-			return
-		}
-	}
-
-	transactions, err := h.transactionService.GetTransactionsByCategory(c.Request.Context(), categoryID, limit, offset)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "Failed to fetch transactions",
-			"details": err.Error(),
-		})
-		return
-	}
-
-	c.JSON(http.StatusOK, gin.H{
-		"transactions": transactions,
-		"count":        len(transactions),
-		"category_id":  categoryID,
-		"limit":        limit,
-		"offset":       offset,
 	})
 }
 
@@ -921,7 +815,7 @@ func (h *TransactionHandler) GetAverageByCategory(c *gin.Context) {
 	var startDate, endDate *time.Time
 
 	if s := c.Query("start_date"); s != "" {
-		parsed, err := time.Parse("2006-01-02", s)
+		parsed, err := time.ParseInLocation("2006-01-02", s, h.loc)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error":   "Invalid start_date format",
@@ -933,7 +827,7 @@ func (h *TransactionHandler) GetAverageByCategory(c *gin.Context) {
 	}
 
 	if s := c.Query("end_date"); s != "" {
-		parsed, err := time.Parse("2006-01-02", s)
+		parsed, err := time.ParseInLocation("2006-01-02", s, h.loc)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error":   "Invalid end_date format",
@@ -944,7 +838,7 @@ func (h *TransactionHandler) GetAverageByCategory(c *gin.Context) {
 		endDate = &parsed
 	}
 
-	result, err := h.transactionService.GetAverageByCategory(c.Request.Context(), startDate, endDate)
+	result, totalIncome, err := h.transactionService.GetAverageByCategory(c.Request.Context(), startDate, endDate)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error":   "Failed to get average by category",
@@ -955,6 +849,7 @@ func (h *TransactionHandler) GetAverageByCategory(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"averageByCategory": result,
+		"total_income":      totalIncome,
 	})
 }
 
@@ -972,6 +867,7 @@ func (h *TransactionHandler) PrepayTransaction(c *gin.Context) {
 	if err != nil {
 		status := http.StatusInternalServerError
 		if err.Error() == "transaction is not recurring" ||
+			err.Error() == "transaction was already prepaid" ||
 			err.Error() == "recurring transaction has no end_date defined" ||
 			err.Error() == "recurring transaction has no start_date defined" ||
 			err.Error() == "recurring transaction has already ended" ||

--- a/internal/handler/transaction_handler_test.go
+++ b/internal/handler/transaction_handler_test.go
@@ -1,0 +1,106 @@
+package handler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ArthurWerle/transactions/internal/model"
+)
+
+func datePtr(year int, month time.Month, day int) *time.Time {
+	d := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+	return &d
+}
+
+func recurring(start, end *time.Time, amount float64) *model.Transaction {
+	return &model.Transaction{IsRecurring: true, StartDate: start, EndDate: end, Amount: amount}
+}
+
+// The convention: the current month counts as paid, so paid + left always
+// covers the whole schedule (F4).
+func TestComputeTotalPaidAndLeft(t *testing.T) {
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		tx       *model.Transaction
+		wantPaid *float64
+		wantLeft *float64
+	}{
+		{
+			name:     "mid-schedule: Jan-Dec 2026 viewed in July",
+			tx:       recurring(datePtr(2026, 1, 10), datePtr(2026, 12, 10), 100),
+			wantPaid: f(700), // Jan..Jul = 7 months
+			wantLeft: f(500), // Aug..Dec = 5 months
+		},
+		{
+			name:     "starts this month",
+			tx:       recurring(datePtr(2026, 7, 1), datePtr(2026, 9, 1), 100),
+			wantPaid: f(100),
+			wantLeft: f(200),
+		},
+		{
+			name:     "ends this month",
+			tx:       recurring(datePtr(2026, 5, 1), datePtr(2026, 7, 1), 100),
+			wantPaid: f(300),
+			wantLeft: f(0),
+		},
+		{
+			name:     "already ended",
+			tx:       recurring(datePtr(2026, 1, 1), datePtr(2026, 3, 1), 100),
+			wantPaid: f(300),
+			wantLeft: f(0),
+		},
+		{
+			name:     "starts in the future",
+			tx:       recurring(datePtr(2026, 10, 1), datePtr(2026, 12, 1), 100),
+			wantPaid: f(0),
+			wantLeft: f(300),
+		},
+		{
+			name:     "no end date: paid accrues, left unknown",
+			tx:       recurring(datePtr(2026, 4, 1), nil, 100),
+			wantPaid: f(400), // Apr..Jul
+			wantLeft: nil,
+		},
+		{
+			name:     "non-recurring: neither applies",
+			tx:       &model.Transaction{Amount: 100},
+			wantPaid: nil,
+			wantLeft: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			paid := computeTotalPaid(tt.tx, now)
+			left := computeTotalLeft(tt.tx, now)
+			assertFloatPtr(t, "total_paid", paid, tt.wantPaid)
+			assertFloatPtr(t, "total_left", left, tt.wantLeft)
+
+			// paid + left must cover the whole schedule when both are known.
+			if paid != nil && left != nil && tt.tx.EndDate != nil && tt.tx.StartDate != nil {
+				totalMonths := (tt.tx.EndDate.Year()-tt.tx.StartDate.Year())*12 +
+					int(tt.tx.EndDate.Month()) - int(tt.tx.StartDate.Month()) + 1
+				expectedTotal := tt.tx.Amount * float64(totalMonths)
+				if *paid+*left != expectedTotal {
+					t.Errorf("paid (%v) + left (%v) = %v, expected schedule total %v", *paid, *left, *paid+*left, expectedTotal)
+				}
+			}
+		})
+	}
+}
+
+func f(v float64) *float64 { return &v }
+
+func assertFloatPtr(t *testing.T, label string, got, want *float64) {
+	t.Helper()
+	switch {
+	case want == nil && got != nil:
+		t.Errorf("%s: expected nil, got %v", label, *got)
+	case want != nil && got == nil:
+		t.Errorf("%s: expected %v, got nil", label, *want)
+	case want != nil && got != nil && *want != *got:
+		t.Errorf("%s: expected %v, got %v", label, *want, *got)
+	}
+}

--- a/internal/migrations/20260703_frequency_monthly_enum.sql
+++ b/internal/migrations/20260703_frequency_monthly_enum.sql
@@ -1,0 +1,35 @@
+-- Monthly is the only supported recurrence frequency (F2).
+-- This file must stay idempotent: the migration runner re-executes every
+-- file on each boot.
+
+DO $$
+    BEGIN
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_type WHERE typname = 'transaction_frequency'
+        ) THEN
+            CREATE TYPE transaction_frequency AS ENUM ('monthly');
+        END IF;
+    END;
+$$;
+
+-- Normalize legacy values before the cast. Every calculation always assumed
+-- monthly, so this makes stored data match reported behavior.
+UPDATE transactions
+SET frequency = 'monthly'
+WHERE frequency IS NOT NULL
+  AND frequency::text <> 'monthly';
+
+DO $$
+    BEGIN
+        IF EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_name = 'transactions'
+              AND column_name = 'frequency'
+              AND udt_name <> 'transaction_frequency'
+        ) THEN
+            ALTER TABLE transactions
+                ALTER COLUMN frequency TYPE transaction_frequency
+                USING frequency::text::transaction_frequency;
+        END IF;
+    END;
+$$;

--- a/internal/model/transactions.go
+++ b/internal/model/transactions.go
@@ -23,7 +23,7 @@ type Transaction struct {
 	Origin        string         `gorm:"type:transaction_origin;not null;default:web" json:"origin"`
 	Description   *string        `gorm:"type:text" json:"description"`
 	Date          *time.Time     `gorm:"type:timestamptz" json:"date"`
-	Frequency     *string        `gorm:"type:varchar(50)" json:"frequency"`
+	Frequency     *string        `gorm:"type:transaction_frequency" json:"frequency"`
 	StartDate     *time.Time     `gorm:"type:date;column:start_date" json:"start_date"`
 	EndDate       *time.Time     `gorm:"type:date;column:end_date" json:"end_date"`
 	PrepaidFromID *uint          `gorm:"column:prepaid_from_id" json:"prepaid_from_id"`

--- a/internal/repository/transactions_repository.go
+++ b/internal/repository/transactions_repository.go
@@ -1,7 +1,6 @@
 package repository
 
 import (
-	"log"
 	"time"
 
 	"github.com/ArthurWerle/transactions/internal/model"
@@ -20,6 +19,12 @@ type RecurringCategoryExpense struct {
 	Amount       float64    `gorm:"column:amount"`
 	StartDate    *time.Time `gorm:"column:start_date"`
 	EndDate      *time.Time `gorm:"column:end_date"`
+}
+
+type RecurringAmount struct {
+	Amount    float64    `gorm:"column:amount"`
+	StartDate *time.Time `gorm:"column:start_date"`
+	EndDate   *time.Time `gorm:"column:end_date"`
 }
 
 type MonthlyTypeTotal struct {
@@ -44,19 +49,18 @@ type TransactionsRepository interface {
 	CountAll() (int64, error)
 	FindAllWithFilters(currentMonth bool, categoryIDs []uint, searchQuery string, startDate, endDate *time.Time, transactionType string, limit, offset int) ([]model.Transaction, error)
 	CountAllWithFilters(currentMonth bool, categoryIDs []uint, searchQuery string, startDate, endDate *time.Time, transactionType string) (int64, error)
+	SumAllWithFilters(currentMonth bool, categoryIDs []uint, searchQuery string, startDate, endDate *time.Time, transactionType string) (float64, error)
 	FindBiggest(month, year int) ([]model.Transaction, error)
 	FindLatest() ([]model.Transaction, error)
 	Update(transaction *model.Transaction) error
 	Delete(id uint) error
 	FindByDateRange(startDate, endDate time.Time) ([]model.Transaction, error)
-	FindByType(transactionType string, limit, offset int) ([]model.Transaction, error)
-	FindRecurring() ([]model.Transaction, error)
 	FindByCategories(categoriesIDs []uint, limit, offset int) ([]model.Transaction, error)
-	FindByCategory(categoryID uint, limit, offset int) ([]model.Transaction, error)
-	PrepayTransaction(original *model.Transaction, prepayment *model.Transaction) error
 	FindEarliestDate(startDate, endDate *time.Time) (*time.Time, error)
 	FindExpenseSummaryByCategory(startDate, endDate *time.Time) ([]CategoryExpenseSummary, error)
 	FindRecurringExpensesInRange(startDate, endDate *time.Time) ([]RecurringCategoryExpense, error)
+	FindIncomeTotalInRange(startDate, endDate *time.Time) (float64, error)
+	FindRecurringIncomesInRange(startDate, endDate *time.Time) ([]RecurringAmount, error)
 	FindCurrentMonthTotalByType(transactionType string) (float64, error)
 	FindCurrentMonthTotalByTypeAndCategory(transactionType string, categoryID uint) (float64, error)
 	FindNonRecurringMonthlyTotalsByType() ([]MonthlyTypeTotal, error)
@@ -64,11 +68,12 @@ type TransactionsRepository interface {
 }
 
 type transactionsRepository struct {
-	db *gorm.DB
+	db  *gorm.DB
+	loc *time.Location
 }
 
-func NewTransactionsRepository(db *gorm.DB) TransactionsRepository {
-	return &transactionsRepository{db: db}
+func NewTransactionsRepository(db *gorm.DB, loc *time.Location) TransactionsRepository {
+	return &transactionsRepository{db: db, loc: loc}
 }
 
 func WithIsPrepaid(db *gorm.DB) *gorm.DB {
@@ -77,6 +82,44 @@ func WithIsPrepaid(db *gorm.DB) *gorm.DB {
 		WHERE t2.prepaid_from_id = transactions.id
 		AND t2.deleted_at IS NULL
 	) AS is_prepaid`)
+}
+
+// monthBounds returns the half-open interval [first instant of the month,
+// first instant of the next month) in the given location.
+func monthBounds(year int, month time.Month, loc *time.Location) (time.Time, time.Time) {
+	start := time.Date(year, month, 1, 0, 0, 0, 0, loc)
+	return start, start.AddDate(0, 1, 0)
+}
+
+// periodCondition returns a WHERE fragment matching transactions active in the
+// half-open interval [start, end): one-off transactions by their timestamp,
+// recurring ones by schedule overlap. A nil bound is unbounded, so a
+// start-only filter also matches recurring schedules that begin in the
+// future. start_date/end_date are DATE columns, so the recurring legs compare
+// against the bound's calendar date in the reporting timezone.
+func (r *transactionsRepository) periodCondition(start, end *time.Time) (string, []interface{}) {
+	nonRecurring := "is_recurring = false AND date IS NOT NULL"
+	args := []interface{}{}
+	if start != nil {
+		nonRecurring += " AND date >= ?"
+		args = append(args, *start)
+	}
+	if end != nil {
+		nonRecurring += " AND date < ?"
+		args = append(args, *end)
+	}
+
+	recurring := "is_recurring = true AND start_date IS NOT NULL"
+	if end != nil {
+		recurring += " AND start_date < ?"
+		args = append(args, end.In(r.loc).Format("2006-01-02"))
+	}
+	if start != nil {
+		recurring += " AND (end_date IS NULL OR end_date >= ?)"
+		args = append(args, start.In(r.loc).Format("2006-01-02"))
+	}
+
+	return "((" + nonRecurring + ") OR (" + recurring + "))", args
 }
 
 func (r *transactionsRepository) Create(transaction *model.Transaction) error {
@@ -117,24 +160,13 @@ func (r *transactionsRepository) buildFilterQuery(currentMonth bool, categoryIDs
 	query := r.db.Model(&model.Transaction{})
 
 	if currentMonth {
-		now := time.Now()
-		startOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
-		endOfMonth := startOfMonth.AddDate(0, 1, 0).Add(-time.Second)
-		query = query.Where("(date >= ? AND date <= ?) OR (is_recurring = true AND start_date <= ? AND (end_date >= ? OR end_date IS NULL))", startOfMonth, endOfMonth, endOfMonth, startOfMonth)
+		now := time.Now().In(r.loc)
+		start, end := monthBounds(now.Year(), now.Month(), r.loc)
+		cond, args := r.periodCondition(&start, &end)
+		query = query.Where(cond, args...)
 	} else if startDate != nil || endDate != nil {
-		sd := time.Time{}
-		if startDate != nil {
-			sd = *startDate
-		}
-		ed := time.Now()
-		if endDate != nil {
-			ed = *endDate
-		}
-		query = query.Where(
-			"(is_recurring = ? AND date >= ? AND date <= ?) OR (is_recurring = ? AND start_date <= ? AND (end_date >= ? OR end_date IS NULL))",
-			false, sd, ed,
-			true, ed, sd,
-		)
+		cond, args := r.periodCondition(startDate, endDate)
+		query = query.Where(cond, args...)
 	}
 
 	if len(categoryIDs) > 0 {
@@ -165,6 +197,16 @@ func (r *transactionsRepository) CountAllWithFilters(currentMonth bool, category
 	return count, err
 }
 
+func (r *transactionsRepository) SumAllWithFilters(currentMonth bool, categoryIDs []uint, searchQuery string, startDate, endDate *time.Time, transactionType string) (float64, error) {
+	var result struct {
+		Total float64 `gorm:"column:total"`
+	}
+	err := r.buildFilterQuery(currentMonth, categoryIDs, searchQuery, startDate, endDate, transactionType).
+		Select("COALESCE(SUM(amount), 0) as total").
+		Scan(&result).Error
+	return result.Total, err
+}
+
 func (r *transactionsRepository) FindLatest() ([]model.Transaction, error) {
 	var transactions []model.Transaction
 	err := r.db.Model(&model.Transaction{}).Scopes(WithIsPrepaid).Preload("Subcategory").Preload("Location").Where("date IS NOT NULL AND type = ?", model.Expense).Order("date DESC").Limit(3).Find(&transactions).Error
@@ -173,12 +215,13 @@ func (r *transactionsRepository) FindLatest() ([]model.Transaction, error) {
 
 func (r *transactionsRepository) FindBiggest(month, year int) ([]model.Transaction, error) {
 	var transactions []model.Transaction
-	startOfMonth := time.Date(year, time.Month(month), 1, 0, 0, 0, 0, time.UTC)
-	endOfMonth := startOfMonth.AddDate(0, 1, 0).Add(-time.Second)
-	err := r.db.Model(&model.Transaction{}).Scopes(WithIsPrepaid).Preload("Subcategory").Preload("Location").Where(
-		"type = ? AND ((is_recurring = false AND date >= ? AND date <= ?) OR (is_recurring = true AND start_date <= ? AND (end_date >= ? OR end_date IS NULL)))",
-		model.Expense, startOfMonth, endOfMonth, endOfMonth, startOfMonth,
-	).Order("amount DESC").Limit(3).Find(&transactions).Error
+	start, end := monthBounds(year, time.Month(month), r.loc)
+	cond, args := r.periodCondition(&start, &end)
+	err := r.db.Model(&model.Transaction{}).Scopes(WithIsPrepaid).Preload("Subcategory").Preload("Location").
+		Where("type = ?", model.Expense).
+		Where("prepaid_from_id IS NULL").
+		Where(cond, args...).
+		Order("amount DESC").Limit(3).Find(&transactions).Error
 	return transactions, err
 }
 
@@ -190,43 +233,13 @@ func (r *transactionsRepository) Delete(id uint) error {
 	return r.db.Delete(&model.Transaction{}, id).Error
 }
 
+// FindByDateRange treats endDate as exclusive; callers convert inclusive
+// calendar days to the half-open form before calling.
 func (r *transactionsRepository) FindByDateRange(startDate, endDate time.Time) ([]model.Transaction, error) {
 	var transactions []model.Transaction
-	endOfDay := time.Date(endDate.Year(), endDate.Month(), endDate.Day()+1, 0, 0, 0, 0, endDate.Location())
-	log.Printf("FindByDateRange: startDate=%s endDate=%s endOfDay=%s", startDate.Format(time.RFC3339), endDate.Format(time.RFC3339), endOfDay.Format(time.RFC3339))
-	err := r.db.Scopes(WithIsPrepaid).Preload("Subcategory").Preload("Location").Where(
-		"(is_recurring = ? AND date >= ? AND date < ?) OR (is_recurring = ? AND start_date < ? AND (end_date >= ? OR end_date IS NULL))",
-		false, startDate, endOfDay,
-		true, endOfDay, startDate,
-	).
-		Order("date DESC").
-		Find(&transactions).Error
-	return transactions, err
-}
-
-func (r *transactionsRepository) FindByType(transactionType string, limit, offset int) ([]model.Transaction, error) {
-	var transactions []model.Transaction
-	err := r.db.Scopes(WithIsPrepaid).Preload("Subcategory").Preload("Location").Where("type = ?", transactionType).
-		Limit(limit).
-		Offset(offset).
-		Order("date DESC").
-		Find(&transactions).Error
-	return transactions, err
-}
-
-func (r *transactionsRepository) FindRecurring() ([]model.Transaction, error) {
-	var transactions []model.Transaction
-	err := r.db.Scopes(WithIsPrepaid).Preload("Subcategory").Preload("Location").Where("is_recurring = ?", true).
-		Order("start_date DESC").
-		Find(&transactions).Error
-	return transactions, err
-}
-
-func (r *transactionsRepository) FindByCategory(categoryID uint, limit, offset int) ([]model.Transaction, error) {
-	var transactions []model.Transaction
-	err := r.db.Scopes(WithIsPrepaid).Preload("Subcategory").Preload("Location").Where("category_id = ?", categoryID).
-		Limit(limit).
-		Offset(offset).
+	cond, args := r.periodCondition(&startDate, &endDate)
+	err := r.db.Scopes(WithIsPrepaid).Preload("Subcategory").Preload("Location").
+		Where(cond, args...).
 		Order("date DESC").
 		Find(&transactions).Error
 	return transactions, err
@@ -247,18 +260,6 @@ func (r *transactionsRepository) FindByCategories(categoriesIDs []uint, limit, o
 	return transactions, err
 }
 
-func (r *transactionsRepository) PrepayTransaction(original *model.Transaction, prepayment *model.Transaction) error {
-	return r.db.Transaction(func(tx *gorm.DB) error {
-		if err := tx.Save(original).Error; err != nil {
-			return err
-		}
-		if err := tx.Create(prepayment).Error; err != nil {
-			return err
-		}
-		return nil
-	})
-}
-
 func (r *transactionsRepository) FindEarliestDate(startDate, endDate *time.Time) (*time.Time, error) {
 	var result struct {
 		MinDate *time.Time `gorm:"column:min_date"`
@@ -270,8 +271,8 @@ func (r *transactionsRepository) FindEarliestDate(startDate, endDate *time.Time)
 		args = append(args, *startDate)
 	}
 	if endDate != nil {
-		query += " AND date <= ?"
-		args = append(args, *endDate)
+		query += " AND date < ?"
+		args = append(args, endDate.AddDate(0, 0, 1))
 	}
 	err := r.db.Raw(query, args...).Scan(&result).Error
 	if err != nil {
@@ -292,15 +293,16 @@ func (r *transactionsRepository) FindExpenseSummaryByCategory(startDate, endDate
 		WHERE t.type = 'expense'
 			AND t.category_id IS NOT NULL
 			AND t.date IS NOT NULL
-			AND t.deleted_at IS NULL`
+			AND t.deleted_at IS NULL
+			AND t.prepaid_from_id IS NULL`
 	args := []interface{}{}
 	if startDate != nil {
 		query += " AND t.date >= ?"
 		args = append(args, *startDate)
 	}
 	if endDate != nil {
-		query += " AND t.date <= ?"
-		args = append(args, *endDate)
+		query += " AND t.date < ?"
+		args = append(args, endDate.AddDate(0, 0, 1))
 	}
 	query += " GROUP BY t.category_id, c.name"
 	err := r.db.Raw(query, args...).Scan(&results).Error
@@ -326,76 +328,115 @@ func (r *transactionsRepository) FindRecurringExpensesInRange(startDate, endDate
 	args := []interface{}{}
 	if endDate != nil {
 		query += " AND t.start_date <= ?"
-		args = append(args, *endDate)
+		args = append(args, endDate.In(r.loc).Format("2006-01-02"))
 	}
 	if startDate != nil {
 		query += " AND (t.end_date IS NULL OR t.end_date >= ?)"
+		args = append(args, startDate.In(r.loc).Format("2006-01-02"))
+	}
+	err := r.db.Raw(query, args...).Scan(&results).Error
+	return results, err
+}
+
+func (r *transactionsRepository) FindIncomeTotalInRange(startDate, endDate *time.Time) (float64, error) {
+	var result struct {
+		Total float64 `gorm:"column:total"`
+	}
+	query := `
+		SELECT COALESCE(SUM(amount), 0) as total
+		FROM transactions
+		WHERE type = 'income'
+		  AND is_recurring = false
+		  AND date IS NOT NULL
+		  AND deleted_at IS NULL
+		  AND prepaid_from_id IS NULL`
+	args := []interface{}{}
+	if startDate != nil {
+		query += " AND date >= ?"
 		args = append(args, *startDate)
+	}
+	if endDate != nil {
+		query += " AND date < ?"
+		args = append(args, endDate.AddDate(0, 0, 1))
+	}
+	err := r.db.Raw(query, args...).Scan(&result).Error
+	return result.Total, err
+}
+
+func (r *transactionsRepository) FindRecurringIncomesInRange(startDate, endDate *time.Time) ([]RecurringAmount, error) {
+	var results []RecurringAmount
+	query := `
+		SELECT amount, start_date, end_date
+		FROM transactions
+		WHERE type = 'income'
+		  AND is_recurring = true
+		  AND start_date IS NOT NULL
+		  AND deleted_at IS NULL`
+	args := []interface{}{}
+	if endDate != nil {
+		query += " AND start_date <= ?"
+		args = append(args, endDate.In(r.loc).Format("2006-01-02"))
+	}
+	if startDate != nil {
+		query += " AND (end_date IS NULL OR end_date >= ?)"
+		args = append(args, startDate.In(r.loc).Format("2006-01-02"))
 	}
 	err := r.db.Raw(query, args...).Scan(&results).Error
 	return results, err
 }
 
 func (r *transactionsRepository) FindCurrentMonthTotalByType(transactionType string) (float64, error) {
-	now := time.Now()
-	startOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
-	endOfMonth := startOfMonth.AddDate(0, 1, 0).Add(-time.Second)
+	now := time.Now().In(r.loc)
+	start, end := monthBounds(now.Year(), now.Month(), r.loc)
+	cond, args := r.periodCondition(&start, &end)
 
 	var result struct {
 		Total float64 `gorm:"column:total"`
 	}
-	err := r.db.Raw(`
-		SELECT COALESCE(SUM(amount), 0) as total
-		FROM transactions
-		WHERE type = ?
-		  AND deleted_at IS NULL
-		  AND (
-		    (is_recurring = false AND date >= ? AND date <= ?)
-		    OR
-		    (is_recurring = true AND start_date <= ? AND (end_date >= ? OR end_date IS NULL))
-		  )
-	`, transactionType, startOfMonth, endOfMonth, endOfMonth, startOfMonth).Scan(&result).Error
+	err := r.db.Model(&model.Transaction{}).
+		Select("COALESCE(SUM(amount), 0) as total").
+		Where("type = ?", transactionType).
+		Where("prepaid_from_id IS NULL").
+		Where(cond, args...).
+		Scan(&result).Error
 
 	return result.Total, err
 }
 
 func (r *transactionsRepository) FindCurrentMonthTotalByTypeAndCategory(transactionType string, categoryID uint) (float64, error) {
-	now := time.Now()
-	startOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
-	endOfMonth := startOfMonth.AddDate(0, 1, 0).Add(-time.Second)
+	now := time.Now().In(r.loc)
+	start, end := monthBounds(now.Year(), now.Month(), r.loc)
+	cond, args := r.periodCondition(&start, &end)
 
 	var result struct {
 		Total float64 `gorm:"column:total"`
 	}
-	err := r.db.Raw(`
-		SELECT COALESCE(SUM(amount), 0) as total
-		FROM transactions
-		WHERE type = ?
-		  AND category_id = ?
-		  AND deleted_at IS NULL
-		  AND (
-		    (is_recurring = false AND date >= ? AND date <= ?)
-		    OR
-		    (is_recurring = true AND start_date <= ? AND (end_date >= ? OR end_date IS NULL))
-		  )
-	`, transactionType, categoryID, startOfMonth, endOfMonth, endOfMonth, startOfMonth).Scan(&result).Error
+	err := r.db.Model(&model.Transaction{}).
+		Select("COALESCE(SUM(amount), 0) as total").
+		Where("type = ?", transactionType).
+		Where("category_id = ?", categoryID).
+		Where("prepaid_from_id IS NULL").
+		Where(cond, args...).
+		Scan(&result).Error
 
 	return result.Total, err
 }
 
 func (r *transactionsRepository) FindNonRecurringMonthlyTotalsByType() ([]MonthlyTypeTotal, error) {
 	var results []MonthlyTypeTotal
+	tz := r.loc.String()
 	err := r.db.Raw(`
 		SELECT type,
-		       EXTRACT(year FROM date)::int  AS year,
-		       EXTRACT(month FROM date)::int AS month,
-		       SUM(amount)                   AS monthly_sum
+		       EXTRACT(year FROM (date AT TIME ZONE ?))::int  AS year,
+		       EXTRACT(month FROM (date AT TIME ZONE ?))::int AS month,
+		       SUM(amount)                                    AS monthly_sum
 		FROM transactions
 		WHERE is_recurring = false
 		  AND date IS NOT NULL
 		  AND deleted_at IS NULL
+		  AND prepaid_from_id IS NULL
 		GROUP BY type, year, month
-	`).Scan(&results).Error
+	`, tz, tz).Scan(&results).Error
 	return results, err
 }
 

--- a/internal/service/transactions_service.go
+++ b/internal/service/transactions_service.go
@@ -11,6 +11,17 @@ import (
 	"github.com/ArthurWerle/transactions/internal/repository"
 )
 
+// MonthlyFrequency is the only supported recurrence frequency.
+const MonthlyFrequency = "monthly"
+
+// ErrInvalidTransaction is the sentinel wrapped by every transaction-shape
+// validation error, so handlers can map them to 400 with errors.Is.
+var ErrInvalidTransaction = errors.New("invalid transaction")
+
+func invalidf(format string, args ...interface{}) error {
+	return fmt.Errorf("%w: %s", ErrInvalidTransaction, fmt.Sprintf(format, args...))
+}
+
 type PrepayResult struct {
 	OriginalTransaction *model.Transaction `json:"original_transaction"`
 	PrepayTransaction   *model.Transaction `json:"prepay_transaction"`
@@ -26,18 +37,15 @@ type TransactionPercentages struct {
 type TransactionsService interface {
 	CreateTransaction(ctx context.Context, transaction *model.Transaction) error
 	GetAverageByType(ctx context.Context) ([]AverageType, error)
-	GetAverageByCategory(ctx context.Context, startDate, endDate *time.Time) ([]AverageByCategory, error)
+	GetAverageByCategory(ctx context.Context, startDate, endDate *time.Time) ([]AverageByCategory, float64, error)
 	GetTransactionByID(ctx context.Context, id uint) (*model.Transaction, error)
-	GetTransactions(ctx context.Context, limit, offset int) ([]model.Transaction, int64, error)
-	GetTransactionsWithFilters(ctx context.Context, currentMonth bool, categoryIDs []uint, searchQuery string, startDate, endDate *time.Time, transactionType string, limit, offset int) ([]model.Transaction, int64, error)
+	GetTransactions(ctx context.Context, limit, offset int) ([]model.Transaction, int64, float64, error)
+	GetTransactionsWithFilters(ctx context.Context, currentMonth bool, categoryIDs []uint, searchQuery string, startDate, endDate *time.Time, transactionType string, limit, offset int) ([]model.Transaction, int64, float64, error)
 	GetLatestTransactions(ctx context.Context) ([]model.Transaction, error)
 	GetBiggestTransactions(ctx context.Context, month, year int) ([]model.Transaction, error)
 	UpdateTransaction(ctx context.Context, transaction *model.Transaction) error
 	DeleteTransaction(ctx context.Context, id uint) error
 	GetTransactionsByDateRange(ctx context.Context, startDate, endDate time.Time) ([]model.Transaction, error)
-	GetTransactionsByType(ctx context.Context, transactionType string, limit, offset int) ([]model.Transaction, error)
-	GetRecurringTransactions(ctx context.Context) ([]model.Transaction, error)
-	GetTransactionsByCategory(ctx context.Context, categoryID uint, limit, offset int) ([]model.Transaction, error)
 	GetTransactionsByCategories(ctx context.Context, categoriesIDs []uint, limit, offset int) ([]model.Transaction, error)
 	PrepayTransaction(ctx context.Context, id uint) (*PrepayResult, error)
 	GetTransactionMonthlyPercentages(ctx context.Context, tx *model.Transaction) (*TransactionPercentages, error)
@@ -45,15 +53,67 @@ type TransactionsService interface {
 
 type transactionsService struct {
 	transactionRepo repository.TransactionsRepository
+	loc             *time.Location
 }
 
-func NewTransactionsService(transactionRepo repository.TransactionsRepository) TransactionsService {
+func NewTransactionsService(transactionRepo repository.TransactionsRepository, loc *time.Location) TransactionsService {
 	return &transactionsService{
 		transactionRepo: transactionRepo,
+		loc:             loc,
+	}
+}
+
+// validateTransactionShape enforces the recurring-transaction invariant:
+// recurring rows are schedules (start_date set, no date, monthly frequency),
+// one-offs are dated rows with no schedule fields.
+func validateTransactionShape(t *model.Transaction) error {
+	if t.IsRecurring {
+		if t.StartDate == nil {
+			return invalidf("recurring transaction requires start_date")
+		}
+		if t.Date != nil {
+			return invalidf("recurring transaction must not have date")
+		}
+		if t.Frequency == nil || *t.Frequency != MonthlyFrequency {
+			return invalidf("frequency must be '%s'", MonthlyFrequency)
+		}
+		if t.EndDate != nil && t.EndDate.Before(*t.StartDate) {
+			return invalidf("end_date must not be before start_date")
+		}
+	} else {
+		if t.Date == nil {
+			return invalidf("non-recurring transaction requires date")
+		}
+		if t.StartDate != nil || t.EndDate != nil || t.Frequency != nil {
+			return invalidf("non-recurring transaction must not have start_date, end_date or frequency")
+		}
+	}
+	return nil
+}
+
+// normalizeTransactionShape clears fields that don't belong to the
+// transaction's shape, so updates that flip is_recurring (or edit legacy rows
+// created before the invariant was enforced) heal instead of erroring.
+func normalizeTransactionShape(t *model.Transaction) {
+	if t.IsRecurring {
+		t.Date = nil
+		f := MonthlyFrequency
+		t.Frequency = &f
+	} else {
+		t.StartDate = nil
+		t.EndDate = nil
+		t.Frequency = nil
 	}
 }
 
 func (s *transactionsService) CreateTransaction(ctx context.Context, transaction *model.Transaction) error {
+	if transaction.IsRecurring && transaction.Frequency == nil {
+		f := MonthlyFrequency
+		transaction.Frequency = &f
+	}
+	if err := validateTransactionShape(transaction); err != nil {
+		return err
+	}
 	return s.transactionRepo.Create(transaction)
 }
 
@@ -61,13 +121,17 @@ func (s *transactionsService) GetTransactionByID(ctx context.Context, id uint) (
 	return s.transactionRepo.FindByID(id)
 }
 
-func (s *transactionsService) GetTransactions(ctx context.Context, limit, offset int) ([]model.Transaction, int64, error) {
+func (s *transactionsService) GetTransactions(ctx context.Context, limit, offset int) ([]model.Transaction, int64, float64, error) {
 	total, err := s.transactionRepo.CountAll()
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, 0, err
+	}
+	sum, err := s.transactionRepo.SumAllWithFilters(false, nil, "", nil, nil, "")
+	if err != nil {
+		return nil, 0, 0, err
 	}
 	transactions, err := s.transactionRepo.FindAll(limit, offset)
-	return transactions, total, err
+	return transactions, total, sum, err
 }
 
 func (s *transactionsService) GetLatestTransactions(ctx context.Context) ([]model.Transaction, error) {
@@ -78,16 +142,24 @@ func (s *transactionsService) GetBiggestTransactions(ctx context.Context, month,
 	return s.transactionRepo.FindBiggest(month, year)
 }
 
-func (s *transactionsService) GetTransactionsWithFilters(ctx context.Context, currentMonth bool, categoryIDs []uint, searchQuery string, startDate, endDate *time.Time, transactionType string, limit, offset int) ([]model.Transaction, int64, error) {
+func (s *transactionsService) GetTransactionsWithFilters(ctx context.Context, currentMonth bool, categoryIDs []uint, searchQuery string, startDate, endDate *time.Time, transactionType string, limit, offset int) ([]model.Transaction, int64, float64, error) {
 	total, err := s.transactionRepo.CountAllWithFilters(currentMonth, categoryIDs, searchQuery, startDate, endDate, transactionType)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, 0, err
+	}
+	sum, err := s.transactionRepo.SumAllWithFilters(currentMonth, categoryIDs, searchQuery, startDate, endDate, transactionType)
+	if err != nil {
+		return nil, 0, 0, err
 	}
 	transactions, err := s.transactionRepo.FindAllWithFilters(currentMonth, categoryIDs, searchQuery, startDate, endDate, transactionType, limit, offset)
-	return transactions, total, err
+	return transactions, total, sum, err
 }
 
 func (s *transactionsService) UpdateTransaction(ctx context.Context, transaction *model.Transaction) error {
+	normalizeTransactionShape(transaction)
+	if err := validateTransactionShape(transaction); err != nil {
+		return err
+	}
 	return s.transactionRepo.Update(transaction)
 }
 
@@ -101,12 +173,23 @@ type AverageType struct {
 }
 
 type AverageByCategory struct {
-	CategoryID   uint    `json:"category_id"`
-	CategoryName string  `json:"category_name"`
-	Average      float64 `json:"average"`
-	TotalSpent   float64 `json:"total_spent"`
+	CategoryID      uint     `json:"category_id"`
+	CategoryName    string   `json:"category_name"`
+	Average         float64  `json:"average"`
+	TotalSpent      float64  `json:"total_spent"`
+	PercentOfIncome *float64 `json:"percent_of_income,omitempty"`
 }
 
+// MonthStart normalizes a time to the first instant of its calendar month. For
+// "now" values, convert to the reporting location before calling.
+func MonthStart(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, time.UTC)
+}
+
+// GetAverageByType computes each type's monthly average over that type's own
+// active range, using only complete months (the in-progress month would
+// dilute the average). Types whose data lives entirely in the current month
+// fall back to reporting the current month's total.
 func (s *transactionsService) GetAverageByType(ctx context.Context) ([]AverageType, error) {
 	monthlyTotals, err := s.transactionRepo.FindNonRecurringMonthlyTotalsByType()
 	if err != nil {
@@ -120,118 +203,133 @@ func (s *transactionsService) GetAverageByType(ctx context.Context) ([]AverageTy
 		return nil, fmt.Errorf("failed to fetch recurring transactions by type: %w", err)
 	}
 
-	type yearMonth struct{ year, month int }
-	typeMonthBuckets := make(map[string]map[yearMonth]float64)
+	now := time.Now().In(s.loc)
+	currentMonth := MonthStart(now)
+	lastComplete := currentMonth.AddDate(0, -1, 0)
 
-	// Determine global range start: earliest across non-recurring and recurring start dates
-	var rangeStartYear, rangeStartMonth int
-	rangeStartSet := false
+	type agg struct {
+		total    float64
+		earliest time.Time
+		set      bool
+	}
+	completed := make(map[string]*agg)
+	currentOnly := make(map[string]float64)
 
-	updateRangeStart := func(y, m int) {
-		if !rangeStartSet || y < rangeStartYear || (y == rangeStartYear && m < rangeStartMonth) {
-			rangeStartYear = y
-			rangeStartMonth = m
-			rangeStartSet = true
+	add := func(typeName string, amount float64, month time.Time) {
+		a := completed[typeName]
+		if a == nil {
+			a = &agg{}
+			completed[typeName] = a
+		}
+		a.total += amount
+		if !a.set || month.Before(a.earliest) {
+			a.earliest = month
+			a.set = true
 		}
 	}
 
 	for _, row := range monthlyTotals {
-		if typeMonthBuckets[row.Type] == nil {
-			typeMonthBuckets[row.Type] = make(map[yearMonth]float64)
+		m := time.Date(row.Year, time.Month(row.Month), 1, 0, 0, 0, 0, time.UTC)
+		switch {
+		case m.Before(currentMonth):
+			add(row.Type, row.MonthlySum, m)
+		case m.Equal(currentMonth):
+			currentOnly[row.Type] += row.MonthlySum
 		}
-		typeMonthBuckets[row.Type][yearMonth{row.Year, row.Month}] += row.MonthlySum
-		updateRangeStart(row.Year, row.Month)
 	}
 
 	for _, tx := range recurringTxs {
 		if tx.StartDate == nil {
 			continue
 		}
-		updateRangeStart(tx.StartDate.Year(), int(tx.StartDate.Month()))
-	}
-
-	if !rangeStartSet {
-		return nil, nil
-	}
-
-	now := time.Now()
-	rangeStart := time.Date(rangeStartYear, time.Month(rangeStartMonth), 1, 0, 0, 0, 0, time.UTC)
-	rangeEnd := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
-	totalMonths := inclusiveMonthCount(rangeStart, rangeEnd)
-	if totalMonths < 1 {
-		totalMonths = 1
-	}
-
-	// Expand each recurring transaction into per-month buckets within its active range
-	for _, tx := range recurringTxs {
-		if tx.StartDate == nil {
-			continue
-		}
-		if typeMonthBuckets[tx.Type] == nil {
-			typeMonthBuckets[tx.Type] = make(map[yearMonth]float64)
-		}
-		txEnd := rangeEnd
+		startM := MonthStart(*tx.StartDate)
+		endM := lastComplete
 		if tx.EndDate != nil {
-			e := time.Date(tx.EndDate.Year(), tx.EndDate.Month(), 1, 0, 0, 0, 0, time.UTC)
-			if e.Before(txEnd) {
-				txEnd = e
+			if e := MonthStart(*tx.EndDate); e.Before(endM) {
+				endM = e
 			}
 		}
-		cur := time.Date(tx.StartDate.Year(), tx.StartDate.Month(), 1, 0, 0, 0, 0, time.UTC)
-		for !cur.After(txEnd) {
-			typeMonthBuckets[tx.Type][yearMonth{cur.Year(), int(cur.Month())}] += tx.Amount
-			cur = cur.AddDate(0, 1, 0)
+		if !endM.Before(startM) {
+			add(tx.Type, tx.Amount*float64(InclusiveMonthCount(startM, endM)), startM)
+		}
+		activeNow := !startM.After(currentMonth) && (tx.EndDate == nil || !MonthStart(*tx.EndDate).Before(currentMonth))
+		if activeNow {
+			currentOnly[tx.Type] += tx.Amount
 		}
 	}
 
 	var result []AverageType
-	for typeName, buckets := range typeMonthBuckets {
-		var total float64
-		for _, sum := range buckets {
-			total += sum
+	for typeName, a := range completed {
+		den := InclusiveMonthCount(a.earliest, lastComplete)
+		if den < 1 {
+			den = 1
 		}
 		result = append(result, AverageType{
 			TypeName: typeName,
-			Average:  total / float64(totalMonths),
+			Average:  a.total / float64(den),
 		})
+	}
+	for typeName, total := range currentOnly {
+		if _, ok := completed[typeName]; !ok {
+			result = append(result, AverageType{TypeName: typeName, Average: total})
+		}
 	}
 
 	return result, nil
 }
 
-func (s *transactionsService) GetAverageByCategory(ctx context.Context, startDate, endDate *time.Time) ([]AverageByCategory, error) {
-	earliestDate, err := s.transactionRepo.FindEarliestDate(startDate, endDate)
+// GetAverageByCategory returns per-category monthly expense averages plus the
+// total income over the same range (for percent-of-income). When no end date
+// is supplied the range stops at the last complete month.
+func (s *transactionsService) GetAverageByCategory(ctx context.Context, startDate, endDate *time.Time) ([]AverageByCategory, float64, error) {
+	now := time.Now().In(s.loc)
+	currentMonth := MonthStart(now)
+	lastComplete := currentMonth.AddDate(0, -1, 0)
+
+	lastDayOf := func(month time.Time) time.Time {
+		return month.AddDate(0, 1, -1)
+	}
+
+	effectiveEnd := endDate
+	if effectiveEnd == nil {
+		e := lastDayOf(lastComplete)
+		effectiveEnd = &e
+	}
+
+	earliestDate, err := s.transactionRepo.FindEarliestDate(startDate, effectiveEnd)
 	if err != nil {
 		log.Printf("[TransactionsService.GetAverageByCategory] ERROR: Failed to fetch earliest date: %v", err)
-		return nil, fmt.Errorf("failed to fetch earliest transaction date: %w", err)
+		return nil, 0, fmt.Errorf("failed to fetch earliest transaction date: %w", err)
 	}
 
 	var rangeStart time.Time
 	if startDate != nil {
-		rangeStart = time.Date(startDate.Year(), startDate.Month(), 1, 0, 0, 0, 0, time.UTC)
+		rangeStart = MonthStart(*startDate)
 	} else if earliestDate != nil {
-		rangeStart = time.Date(earliestDate.Year(), earliestDate.Month(), 1, 0, 0, 0, 0, time.UTC)
+		rangeStart = MonthStart(earliestDate.In(s.loc))
 	} else {
 		rangeStart = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	}
 
-	var rangeEnd time.Time
-	if endDate != nil {
-		rangeEnd = time.Date(endDate.Year(), endDate.Month(), 1, 0, 0, 0, 0, time.UTC)
-	} else {
-		now := time.Now()
-		rangeEnd = time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	rangeEnd := MonthStart(*effectiveEnd)
+
+	// All data in the current (partial) month: include it rather than
+	// reporting an empty range.
+	if endDate == nil && rangeEnd.Before(rangeStart) {
+		rangeEnd = currentMonth
+		e := lastDayOf(currentMonth)
+		effectiveEnd = &e
 	}
 
-	totalMonths := inclusiveMonthCount(rangeStart, rangeEnd)
+	totalMonths := InclusiveMonthCount(rangeStart, rangeEnd)
 	if totalMonths < 1 {
 		totalMonths = 1
 	}
 
-	summaries, err := s.transactionRepo.FindExpenseSummaryByCategory(startDate, endDate)
+	summaries, err := s.transactionRepo.FindExpenseSummaryByCategory(startDate, effectiveEnd)
 	if err != nil {
 		log.Printf("[TransactionsService.GetAverageByCategory] ERROR: Failed to fetch summaries: %v", err)
-		return nil, fmt.Errorf("failed to fetch expense summaries by category: %w", err)
+		return nil, 0, fmt.Errorf("failed to fetch expense summaries by category: %w", err)
 	}
 
 	type categoryInfo struct {
@@ -250,10 +348,24 @@ func (s *transactionsService) GetAverageByCategory(ctx context.Context, startDat
 		}
 	}
 
-	recurringExpenses, err := s.transactionRepo.FindRecurringExpensesInRange(startDate, endDate)
+	recurringExpenses, err := s.transactionRepo.FindRecurringExpensesInRange(startDate, effectiveEnd)
 	if err != nil {
 		log.Printf("[TransactionsService.GetAverageByCategory] ERROR: Failed to fetch recurring expenses: %v", err)
-		return nil, fmt.Errorf("failed to fetch recurring expense summaries by category: %w", err)
+		return nil, 0, fmt.Errorf("failed to fetch recurring expense summaries by category: %w", err)
+	}
+
+	activeMonths := func(startD *time.Time, endD *time.Time) int {
+		activeStart := rangeStart
+		if s := MonthStart(*startD); s.After(activeStart) {
+			activeStart = s
+		}
+		activeEnd := rangeEnd
+		if endD != nil {
+			if e := MonthStart(*endD); e.Before(activeEnd) {
+				activeEnd = e
+			}
+		}
+		return InclusiveMonthCount(activeStart, activeEnd)
 	}
 
 	for _, tx := range recurringExpenses {
@@ -261,21 +373,7 @@ func (s *transactionsService) GetAverageByCategory(ctx context.Context, startDat
 			continue
 		}
 
-		txStart := time.Date(tx.StartDate.Year(), tx.StartDate.Month(), 1, 0, 0, 0, 0, time.UTC)
-		activeStart := rangeStart
-		if txStart.After(activeStart) {
-			activeStart = txStart
-		}
-
-		activeEnd := rangeEnd
-		if tx.EndDate != nil {
-			txEnd := time.Date(tx.EndDate.Year(), tx.EndDate.Month(), 1, 0, 0, 0, 0, time.UTC)
-			if txEnd.Before(activeEnd) {
-				activeEnd = txEnd
-			}
-		}
-
-		months := inclusiveMonthCount(activeStart, activeEnd)
+		months := activeMonths(tx.StartDate, tx.EndDate)
 		if months < 1 {
 			continue
 		}
@@ -292,39 +390,56 @@ func (s *transactionsService) GetAverageByCategory(ctx context.Context, startDat
 		}
 	}
 
+	incomeTotal, err := s.transactionRepo.FindIncomeTotalInRange(startDate, effectiveEnd)
+	if err != nil {
+		log.Printf("[TransactionsService.GetAverageByCategory] ERROR: Failed to fetch income total: %v", err)
+		return nil, 0, fmt.Errorf("failed to fetch income total: %w", err)
+	}
+	recurringIncomes, err := s.transactionRepo.FindRecurringIncomesInRange(startDate, effectiveEnd)
+	if err != nil {
+		log.Printf("[TransactionsService.GetAverageByCategory] ERROR: Failed to fetch recurring incomes: %v", err)
+		return nil, 0, fmt.Errorf("failed to fetch recurring incomes: %w", err)
+	}
+	for _, tx := range recurringIncomes {
+		if tx.StartDate == nil {
+			continue
+		}
+		if months := activeMonths(tx.StartDate, tx.EndDate); months >= 1 {
+			incomeTotal += tx.Amount * float64(months)
+		}
+	}
+
 	var result []AverageByCategory
 	for catID, info := range categoryMap {
-		result = append(result, AverageByCategory{
+		item := AverageByCategory{
 			CategoryID:   catID,
 			CategoryName: info.name,
 			Average:      info.total / float64(totalMonths),
 			TotalSpent:   info.total,
-		})
+		}
+		if incomeTotal > 0 {
+			pct := info.total / incomeTotal * 100
+			item.PercentOfIncome = &pct
+		}
+		result = append(result, item)
 	}
 
-	return result, nil
+	return result, incomeTotal, nil
 }
 
 func (s *transactionsService) GetTransactionsByDateRange(ctx context.Context, startDate, endDate time.Time) ([]model.Transaction, error) {
 	return s.transactionRepo.FindByDateRange(startDate, endDate)
 }
 
-func (s *transactionsService) GetTransactionsByType(ctx context.Context, transactionType string, limit, offset int) ([]model.Transaction, error) {
-	return s.transactionRepo.FindByType(transactionType, limit, offset)
-}
-
-func (s *transactionsService) GetRecurringTransactions(ctx context.Context) ([]model.Transaction, error) {
-	return s.transactionRepo.FindRecurring()
-}
-
-func (s *transactionsService) GetTransactionsByCategory(ctx context.Context, categoryID uint, limit, offset int) ([]model.Transaction, error) {
-	return s.transactionRepo.FindByCategory(categoryID, limit, offset)
-}
-
 func (s *transactionsService) GetTransactionsByCategories(ctx context.Context, categoriesIDs []uint, limit, offset int) ([]model.Transaction, error) {
 	return s.transactionRepo.FindByCategories(categoriesIDs, limit, offset)
 }
 
+// PrepayTransaction records the remaining installments of a recurring
+// transaction as a single dated payment. The original schedule is left
+// untouched: aggregates keep attributing the monthly amount to each month it
+// covers (consumption basis), while the prepayment row exists as the cash
+// record and is excluded from aggregates via prepaid_from_id.
 func (s *transactionsService) PrepayTransaction(ctx context.Context, id uint) (*PrepayResult, error) {
 	original, err := s.transactionRepo.FindByID(id)
 	if err != nil {
@@ -347,15 +462,23 @@ func (s *transactionsService) PrepayTransaction(ctx context.Context, id uint) (*
 		return nil, errors.New("recurring transaction has no start_date defined")
 	}
 
-	now := time.Now()
-	today := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
-	endDate := time.Date(original.EndDate.Year(), original.EndDate.Month(), 1, 0, 0, 0, 0, time.UTC)
+	now := time.Now().In(s.loc)
+	currentMonth := MonthStart(now)
+	startMonth := MonthStart(*original.StartDate)
+	endMonth := MonthStart(*original.EndDate)
 
-	if !endDate.After(today) {
+	if endMonth.Before(currentMonth) {
 		return nil, errors.New("recurring transaction has already ended")
 	}
 
-	remainingMonths := exclusiveMonthCount(today, endDate)
+	var remainingMonths int
+	if startMonth.After(currentMonth) {
+		// The schedule hasn't started yet: every installment is still owed.
+		remainingMonths = InclusiveMonthCount(startMonth, endMonth)
+	} else {
+		// The current month's installment counts as already paid.
+		remainingMonths = ExclusiveMonthCount(currentMonth, endMonth)
+	}
 	if remainingMonths <= 0 {
 		return nil, errors.New("no remaining installments to prepay")
 	}
@@ -368,9 +491,7 @@ func (s *transactionsService) PrepayTransaction(ctx context.Context, id uint) (*
 	}
 	prepayDesc := fmt.Sprintf("Adiantamento de %d parcelas de %s", remainingMonths, originalDesc)
 
-	newEndDate := time.Now()
-	original.EndDate = &newEndDate
-
+	txDate := time.Now()
 	prepayment := &model.Transaction{
 		IsRecurring:   false,
 		CategoryID:    original.CategoryID,
@@ -379,11 +500,11 @@ func (s *transactionsService) PrepayTransaction(ctx context.Context, id uint) (*
 		Type:          original.Type,
 		Subtype:       original.Subtype,
 		Description:   &prepayDesc,
-		Date:          &now,
+		Date:          &txDate,
 		PrepaidFromID: &original.ID,
 	}
 
-	if err := s.transactionRepo.PrepayTransaction(original, prepayment); err != nil {
+	if err := s.transactionRepo.Create(prepayment); err != nil {
 		return nil, err
 	}
 
@@ -395,18 +516,18 @@ func (s *transactionsService) PrepayTransaction(ctx context.Context, id uint) (*
 	}, nil
 }
 
-// inclusiveMonthCount returns the number of calendar months spanned, counting both endpoints.
+// InclusiveMonthCount returns the number of calendar months spanned, counting both endpoints.
 // e.g. Jan → Jan = 1, Jan → Mar = 3.
-func inclusiveMonthCount(start, end time.Time) int {
+func InclusiveMonthCount(start, end time.Time) int {
 	years := end.Year() - start.Year()
 	months := int(end.Month()) - int(start.Month())
 	return years*12 + months + 1
 }
 
-// exclusiveMonthCount returns the number of months strictly after start and up to end.
+// ExclusiveMonthCount returns the number of months strictly after start and up to end.
 // Used when the current month is already paid and only future months remain.
-func exclusiveMonthCount(start, end time.Time) int {
-	return inclusiveMonthCount(start, end) - 1
+func ExclusiveMonthCount(start, end time.Time) int {
+	return InclusiveMonthCount(start, end) - 1
 }
 
 func (s *transactionsService) GetTransactionMonthlyPercentages(ctx context.Context, tx *model.Transaction) (*TransactionPercentages, error) {

--- a/internal/service/transactions_service_test.go
+++ b/internal/service/transactions_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"math"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,13 +13,15 @@ import (
 )
 
 type mockTransactionsRepository struct {
-	transactions    map[uint]*model.Transaction
-	prepayErr       error
-	nonRecurringSums []repository.CategoryExpenseSummary
+	transactions      map[uint]*model.Transaction
+	created           []*model.Transaction
+	nonRecurringSums  []repository.CategoryExpenseSummary
 	recurringExpenses []repository.RecurringCategoryExpense
-	earliestDate    *time.Time
-	monthlyTotals   []repository.MonthlyTypeTotal
-	recurringByType []repository.RecurringTypeTransaction
+	earliestDate      *time.Time
+	monthlyTotals     []repository.MonthlyTypeTotal
+	recurringByType   []repository.RecurringTypeTransaction
+	incomeTotal       float64
+	recurringIncomes  []repository.RecurringAmount
 }
 
 func newMockRepository() *mockTransactionsRepository {
@@ -32,6 +35,7 @@ func (m *mockTransactionsRepository) Create(transaction *model.Transaction) erro
 		transaction.ID = uint(len(m.transactions) + 1)
 	}
 	m.transactions[transaction.ID] = transaction
+	m.created = append(m.created, transaction)
 	return nil
 }
 
@@ -59,6 +63,10 @@ func (m *mockTransactionsRepository) CountAllWithFilters(currentMonth bool, cate
 	return 0, nil
 }
 
+func (m *mockTransactionsRepository) SumAllWithFilters(currentMonth bool, categoryIDs []uint, searchQuery string, startDate, endDate *time.Time, transactionType string) (float64, error) {
+	return 0, nil
+}
+
 func (m *mockTransactionsRepository) FindBiggest(month, year int) ([]model.Transaction, error) {
 	return nil, nil
 }
@@ -80,30 +88,8 @@ func (m *mockTransactionsRepository) FindByDateRange(startDate, endDate time.Tim
 	return nil, nil
 }
 
-func (m *mockTransactionsRepository) FindByType(transactionType string, limit, offset int) ([]model.Transaction, error) {
-	return nil, nil
-}
-
-func (m *mockTransactionsRepository) FindRecurring() ([]model.Transaction, error) {
-	return nil, nil
-}
-
 func (m *mockTransactionsRepository) FindByCategories(categoriesIDs []uint, limit, offset int) ([]model.Transaction, error) {
 	return nil, nil
-}
-
-func (m *mockTransactionsRepository) FindByCategory(categoryID uint, limit, offset int) ([]model.Transaction, error) {
-	return nil, nil
-}
-
-func (m *mockTransactionsRepository) PrepayTransaction(original *model.Transaction, prepayment *model.Transaction) error {
-	if m.prepayErr != nil {
-		return m.prepayErr
-	}
-	m.transactions[original.ID] = original
-	prepayment.ID = uint(len(m.transactions) + 1)
-	m.transactions[prepayment.ID] = prepayment
-	return nil
 }
 
 func (m *mockTransactionsRepository) FindByPrepaidID(prepaidID uint) (*model.Transaction, error) {
@@ -122,6 +108,14 @@ func (m *mockTransactionsRepository) FindRecurringExpensesInRange(startDate, end
 	return m.recurringExpenses, nil
 }
 
+func (m *mockTransactionsRepository) FindIncomeTotalInRange(startDate, endDate *time.Time) (float64, error) {
+	return m.incomeTotal, nil
+}
+
+func (m *mockTransactionsRepository) FindRecurringIncomesInRange(startDate, endDate *time.Time) ([]repository.RecurringAmount, error) {
+	return m.recurringIncomes, nil
+}
+
 func (m *mockTransactionsRepository) FindCurrentMonthTotalByType(transactionType string) (float64, error) {
 	return 0, nil
 }
@@ -138,7 +132,15 @@ func (m *mockTransactionsRepository) FindRecurringTransactionSummaryByType() ([]
 	return m.recurringByType, nil
 }
 
-// ---- inclusiveMonthCount tests ----
+func newTestService(repo repository.TransactionsRepository) TransactionsService {
+	return NewTransactionsService(repo, time.UTC)
+}
+
+func monthsAgo(n int) time.Time {
+	return MonthStart(time.Now().UTC()).AddDate(0, -n, 0)
+}
+
+// ---- month count tests ----
 
 func TestInclusiveMonthCount(t *testing.T) {
 	tests := []struct {
@@ -175,9 +177,9 @@ func TestInclusiveMonthCount(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := inclusiveMonthCount(tt.start, tt.end)
+			result := InclusiveMonthCount(tt.start, tt.end)
 			if result != tt.expected {
-				t.Errorf("inclusiveMonthCount(%v, %v) = %d, expected %d", tt.start, tt.end, result, tt.expected)
+				t.Errorf("InclusiveMonthCount(%v, %v) = %d, expected %d", tt.start, tt.end, result, tt.expected)
 			}
 		})
 	}
@@ -212,27 +214,162 @@ func TestExclusiveMonthCount(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := exclusiveMonthCount(tt.start, tt.end)
+			result := ExclusiveMonthCount(tt.start, tt.end)
 			if result != tt.expected {
-				t.Errorf("exclusiveMonthCount(%v, %v) = %d, expected %d", tt.start, tt.end, result, tt.expected)
+				t.Errorf("ExclusiveMonthCount(%v, %v) = %d, expected %d", tt.start, tt.end, result, tt.expected)
 			}
 		})
 	}
 }
 
+// ---- validateTransactionShape tests ----
+
+func TestTransactionShapeValidation(t *testing.T) {
+	now := time.Now()
+	start := monthsAgo(3)
+	end := monthsAgo(0).AddDate(0, 2, 0)
+	monthly := MonthlyFrequency
+	weekly := "weekly"
+
+	tests := []struct {
+		name    string
+		tx      model.Transaction
+		wantErr string
+	}{
+		{
+			name: "valid one-off",
+			tx:   model.Transaction{Date: &now, Amount: 10, Type: "expense"},
+		},
+		{
+			name: "valid recurring",
+			tx:   model.Transaction{IsRecurring: true, StartDate: &start, EndDate: &end, Amount: 10, Type: "expense"},
+		},
+		{
+			name:    "recurring without start_date",
+			tx:      model.Transaction{IsRecurring: true, EndDate: &end},
+			wantErr: "start_date",
+		},
+		{
+			name:    "recurring with date",
+			tx:      model.Transaction{IsRecurring: true, StartDate: &start, Date: &now},
+			wantErr: "must not have date",
+		},
+		{
+			name:    "recurring with non-monthly frequency",
+			tx:      model.Transaction{IsRecurring: true, StartDate: &start, Frequency: &weekly},
+			wantErr: "monthly",
+		},
+		{
+			name:    "recurring with end before start",
+			tx:      model.Transaction{IsRecurring: true, StartDate: &end, EndDate: &start, Frequency: &monthly},
+			wantErr: "end_date must not be before start_date",
+		},
+		{
+			name:    "one-off without date",
+			tx:      model.Transaction{},
+			wantErr: "requires date",
+		},
+		{
+			name:    "one-off with schedule fields",
+			tx:      model.Transaction{Date: &now, EndDate: &end},
+			wantErr: "must not have start_date, end_date or frequency",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := newMockRepository()
+			svc := newTestService(repo)
+			tx := tt.tx
+			err := svc.CreateTransaction(context.Background(), &tx)
+
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected transaction to be valid, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+			if !errors.Is(err, ErrInvalidTransaction) {
+				t.Errorf("error should wrap ErrInvalidTransaction, got %v", err)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q should mention %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCreateTransaction_DefaultsRecurringFrequencyToMonthly(t *testing.T) {
+	repo := newMockRepository()
+	svc := newTestService(repo)
+
+	start := monthsAgo(1)
+	tx := model.Transaction{IsRecurring: true, StartDate: &start, Amount: 10, Type: "expense"}
+	if err := svc.CreateTransaction(context.Background(), &tx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tx.Frequency == nil || *tx.Frequency != MonthlyFrequency {
+		t.Errorf("expected frequency to default to monthly, got %v", tx.Frequency)
+	}
+}
+
+func TestUpdateTransaction_NormalizesShape(t *testing.T) {
+	repo := newMockRepository()
+	svc := newTestService(repo)
+
+	now := time.Now()
+	start := monthsAgo(2)
+	end := monthsAgo(0)
+	weekly := "weekly"
+
+	// Legacy corrupted row: one-off carrying schedule fields (pre-F1 web data).
+	legacy := model.Transaction{ID: 1, Date: &now, EndDate: &end, Frequency: &weekly, Amount: 10, Type: "expense"}
+	if err := svc.UpdateTransaction(context.Background(), &legacy); err != nil {
+		t.Fatalf("expected legacy row to be healed, got %v", err)
+	}
+	if legacy.EndDate != nil || legacy.Frequency != nil {
+		t.Error("expected schedule fields to be cleared on non-recurring update")
+	}
+
+	// Flip to recurring: date must be cleared, frequency coerced to monthly.
+	rec := model.Transaction{ID: 2, IsRecurring: true, Date: &now, StartDate: &start, Frequency: &weekly, Amount: 10, Type: "expense"}
+	if err := svc.UpdateTransaction(context.Background(), &rec); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Date != nil {
+		t.Error("expected date to be cleared on recurring update")
+	}
+	if rec.Frequency == nil || *rec.Frequency != MonthlyFrequency {
+		t.Errorf("expected frequency coerced to monthly, got %v", rec.Frequency)
+	}
+
+	// Flip to recurring without start_date must fail.
+	bad := model.Transaction{ID: 3, IsRecurring: true, Date: &now, Amount: 10, Type: "expense"}
+	if err := svc.UpdateTransaction(context.Background(), &bad); !errors.Is(err, ErrInvalidTransaction) {
+		t.Errorf("expected ErrInvalidTransaction, got %v", err)
+	}
+}
+
 // ---- GetAverageByType tests ----
 
-func TestGetAverageByType_NonRecurringOnly(t *testing.T) {
-	repo := newMockRepository()
-	svc := NewTransactionsService(repo)
+func lastCompleteMonth() time.Time {
+	return MonthStart(time.Now().UTC()).AddDate(0, -1, 0)
+}
 
-	// Jan 2026: expense $100, income $200
-	// Feb 2026: expense $150
-	// Range: Jan–Feb (2 months for expense), Jan only for income → but total range is Jan–Feb = 2 months
+func TestGetAverageByType_PerTypeRanges(t *testing.T) {
+	repo := newMockRepository()
+	svc := newTestService(repo)
+
+	// income since 6 months ago, expenses only since 2 months ago: each type
+	// must be averaged over its own range (F7).
+	incomeMonth := monthsAgo(6)
+	expenseMonth := monthsAgo(2)
 	repo.monthlyTotals = []repository.MonthlyTypeTotal{
-		{Type: "expense", Year: 2026, Month: 1, MonthlySum: 100},
-		{Type: "expense", Year: 2026, Month: 2, MonthlySum: 150},
-		{Type: "income", Year: 2026, Month: 1, MonthlySum: 200},
+		{Type: "income", Year: incomeMonth.Year(), Month: int(incomeMonth.Month()), MonthlySum: 600},
+		{Type: "expense", Year: expenseMonth.Year(), Month: int(expenseMonth.Month()), MonthlySum: 200},
 	}
 
 	result, err := svc.GetAverageByType(context.Background())
@@ -245,28 +382,70 @@ func TestGetAverageByType_NonRecurringOnly(t *testing.T) {
 		byType[r.TypeName] = r.Average
 	}
 
-	// expense: (100+150) / totalMonths; income: 200 / totalMonths
-	// totalMonths = from Jan 2026 to now (at least 2 months since we're in 2026)
-	// We only verify expense > income since current month is unknown at test time
-	if byType["expense"] <= 0 {
-		t.Errorf("expected positive expense average, got %v", byType["expense"])
+	expectedIncome := 600.0 / float64(InclusiveMonthCount(incomeMonth, lastCompleteMonth()))
+	expectedExpense := 200.0 / float64(InclusiveMonthCount(expenseMonth, lastCompleteMonth()))
+
+	if math.Abs(byType["income"]-expectedIncome) > 0.001 {
+		t.Errorf("income average = %v, expected %v", byType["income"], expectedIncome)
 	}
-	if byType["income"] <= 0 {
-		t.Errorf("expected positive income average, got %v", byType["income"])
-	}
-	// expense total ($250) must be greater than income total ($200)
-	if byType["expense"] <= byType["income"] {
-		t.Errorf("expense average %v should be > income average %v given totals $250 vs $200", byType["expense"], byType["income"])
+	if math.Abs(byType["expense"]-expectedExpense) > 0.001 {
+		t.Errorf("expense average = %v, expected %v", byType["expense"], expectedExpense)
 	}
 }
 
-func TestGetAverageByType_RecurringOnly(t *testing.T) {
+func TestGetAverageByType_ExcludesCurrentMonth(t *testing.T) {
 	repo := newMockRepository()
-	svc := NewTransactionsService(repo)
+	svc := newTestService(repo)
 
-	// Recurring $20/month expense, Jan 2026 → Mar 2026 (3 months active)
-	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	end := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	// One complete month of data plus a huge current-month total: the
+	// in-progress month must not dilute or inflate the average.
+	previous := monthsAgo(1)
+	current := monthsAgo(0)
+	repo.monthlyTotals = []repository.MonthlyTypeTotal{
+		{Type: "expense", Year: previous.Year(), Month: int(previous.Month()), MonthlySum: 100},
+		{Type: "expense", Year: current.Year(), Month: int(current.Month()), MonthlySum: 9999},
+	}
+
+	result, err := svc.GetAverageByType(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 type, got %d", len(result))
+	}
+	if result[0].Average != 100 {
+		t.Errorf("expected average 100 (current month excluded), got %v", result[0].Average)
+	}
+}
+
+func TestGetAverageByType_CurrentMonthOnlyFallback(t *testing.T) {
+	repo := newMockRepository()
+	svc := newTestService(repo)
+
+	current := monthsAgo(0)
+	repo.monthlyTotals = []repository.MonthlyTypeTotal{
+		{Type: "expense", Year: current.Year(), Month: int(current.Month()), MonthlySum: 300},
+	}
+
+	result, err := svc.GetAverageByType(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 type, got %d", len(result))
+	}
+	if result[0].Average != 300 {
+		t.Errorf("expected current-month fallback average 300, got %v", result[0].Average)
+	}
+}
+
+func TestGetAverageByType_RecurringExpansion(t *testing.T) {
+	repo := newMockRepository()
+	svc := newTestService(repo)
+
+	// Recurring $20/month over the last 3 complete months (ends last month).
+	start := monthsAgo(3)
+	end := monthsAgo(1)
 	repo.recurringByType = []repository.RecurringTypeTransaction{
 		{Type: "expense", Amount: 20, StartDate: &start, EndDate: &end},
 	}
@@ -275,40 +454,28 @@ func TestGetAverageByType_RecurringOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
 	if len(result) != 1 {
 		t.Fatalf("expected 1 type, got %d", len(result))
 	}
 
-	entry := result[0]
-	if entry.TypeName != "expense" {
-		t.Errorf("expected type 'expense', got %q", entry.TypeName)
-	}
-
-	// Total contribution: $20 × 3 = $60
-	// totalMonths = Jan 2026 → current month (at least 3, grows over time)
-	// Average ≤ $20 (since totalMonths ≥ 3 and total = $60)
-	if entry.Average > 20 {
-		t.Errorf("average %v should not exceed $20/month (the recurring amount)", entry.Average)
-	}
-	if entry.Average <= 0 {
-		t.Errorf("expected positive average, got %v", entry.Average)
+	// Total = $20 × 3 active months; range = start..lastComplete = 3 months.
+	if math.Abs(result[0].Average-20) > 0.001 {
+		t.Errorf("expected average 20, got %v", result[0].Average)
 	}
 }
 
 func TestGetAverageByType_MixedRecurringAndNon(t *testing.T) {
 	repo := newMockRepository()
-	svc := NewTransactionsService(repo)
+	svc := newTestService(repo)
 
-	// Non-recurring: $50 expense in Jan 2026
-	// Recurring:     $20/month expense Jan–Mar 2026 (3 months = $60)
-	// Total expense: $50 + $60 = $110
-	// Range: Jan 2026 → current month
-	recurringStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	recurringEnd := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	// Non-recurring $50 three months ago; recurring $20/month from 3 months
+	// ago through last month (3 complete months = $60). Range = 3 months.
+	oneOff := monthsAgo(3)
+	recurringStart := monthsAgo(3)
+	recurringEnd := monthsAgo(1)
 
 	repo.monthlyTotals = []repository.MonthlyTypeTotal{
-		{Type: "expense", Year: 2026, Month: 1, MonthlySum: 50},
+		{Type: "expense", Year: oneOff.Year(), Month: int(oneOff.Month()), MonthlySum: 50},
 	}
 	repo.recurringByType = []repository.RecurringTypeTransaction{
 		{Type: "expense", Amount: 20, StartDate: &recurringStart, EndDate: &recurringEnd},
@@ -318,94 +485,19 @@ func TestGetAverageByType_MixedRecurringAndNon(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
 	if len(result) != 1 {
 		t.Fatalf("expected 1 type, got %d", len(result))
 	}
 
-	// Total = $50 (one-off Jan) + $20×3 (recurring Jan–Mar) = $110
-	// Average = $110 / totalMonths; confirm total is $110 by checking average * months
-	now := time.Now()
-	rangeStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	rangeEnd := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
-	expectedMonths := inclusiveMonthCount(rangeStart, rangeEnd)
-	expectedAverage := 110.0 / float64(expectedMonths)
-
-	if math.Abs(result[0].Average-expectedAverage) > 0.01 {
-		t.Errorf("expected average %.4f (110 / %d months), got %.4f", expectedAverage, expectedMonths, result[0].Average)
-	}
-}
-
-func TestGetAverageByType_RecurringWithEndDate(t *testing.T) {
-	repo := newMockRepository()
-	svc := NewTransactionsService(repo)
-
-	// Recurring $100/month expense, Feb 2026 only (start = end = Feb)
-	start := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
-	end := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
-	repo.recurringByType = []repository.RecurringTypeTransaction{
-		{Type: "expense", Amount: 100, StartDate: &start, EndDate: &end},
-	}
-
-	result, err := svc.GetAverageByType(context.Background())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if len(result) != 1 {
-		t.Fatalf("expected 1 type, got %d", len(result))
-	}
-
-	// Total = $100 (1 month active), average = $100 / totalMonths
-	// totalMonths = Feb 2026 → now; average must be ≤ $100 and > 0
-	if result[0].Average > 100 {
-		t.Errorf("average %v should not exceed $100 (single month contribution)", result[0].Average)
-	}
-	if result[0].Average <= 0 {
-		t.Errorf("expected positive average, got %v", result[0].Average)
-	}
-}
-
-func TestGetAverageByType_MultipleTypes(t *testing.T) {
-	repo := newMockRepository()
-	svc := NewTransactionsService(repo)
-
-	// Jan 2026: expense $300, income $500
-	repo.monthlyTotals = []repository.MonthlyTypeTotal{
-		{Type: "expense", Year: 2026, Month: 1, MonthlySum: 300},
-		{Type: "income", Year: 2026, Month: 1, MonthlySum: 500},
-	}
-
-	result, err := svc.GetAverageByType(context.Background())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if len(result) != 2 {
-		t.Fatalf("expected 2 types, got %d", len(result))
-	}
-
-	byType := make(map[string]float64)
-	for _, r := range result {
-		byType[r.TypeName] = r.Average
-	}
-
-	if _, ok := byType["expense"]; !ok {
-		t.Error("missing 'expense' type in result")
-	}
-	if _, ok := byType["income"]; !ok {
-		t.Error("missing 'income' type in result")
-	}
-
-	// income total ($500) > expense total ($300); averages share same denominator
-	if byType["income"] <= byType["expense"] {
-		t.Errorf("income average %v should be > expense average %v", byType["income"], byType["expense"])
+	expected := (50.0 + 60.0) / 3.0
+	if math.Abs(result[0].Average-expected) > 0.001 {
+		t.Errorf("expected average %.4f, got %.4f", expected, result[0].Average)
 	}
 }
 
 func TestGetAverageByType_EmptyData(t *testing.T) {
 	repo := newMockRepository()
-	svc := NewTransactionsService(repo)
+	svc := newTestService(repo)
 
 	result, err := svc.GetAverageByType(context.Background())
 	if err != nil {
@@ -419,12 +511,14 @@ func TestGetAverageByType_EmptyData(t *testing.T) {
 
 // ---- PrepayTransaction tests ----
 
-func TestPrepayTransaction_Success(t *testing.T) {
+func TestPrepayTransaction_StartedSchedule(t *testing.T) {
 	repo := newMockRepository()
-	svc := NewTransactionsService(repo)
+	svc := newTestService(repo)
 
-	startDate := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	endDate := time.Date(2026, 10, 1, 0, 0, 0, 0, time.UTC)
+	// Started 6 months ago, ends 3 months from now. The current month counts
+	// as paid, so 3 installments remain.
+	startDate := monthsAgo(6)
+	endDate := monthsAgo(0).AddDate(0, 3, 0)
 	desc := "Parcela TV"
 
 	original := &model.Transaction{
@@ -444,31 +538,66 @@ func TestPrepayTransaction_Success(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if result.PrepayTransaction == nil {
-		t.Fatal("expected prepay transaction to be created")
+	if result.RemainingMonths != 3 {
+		t.Errorf("expected 3 remaining months, got %d", result.RemainingMonths)
+	}
+	if result.PrepaidAmount != 1500 {
+		t.Errorf("expected prepaid amount 1500, got %v", result.PrepaidAmount)
+	}
+
+	// Consumption basis (F9): the original schedule stays untouched.
+	if !original.EndDate.Equal(endDate) {
+		t.Errorf("original end_date must not change, got %v", original.EndDate)
 	}
 
 	if result.PrepayTransaction.IsRecurring {
 		t.Error("prepay transaction should not be recurring")
 	}
-
 	if result.PrepayTransaction.PrepaidFromID == nil || *result.PrepayTransaction.PrepaidFromID != 1 {
 		t.Error("prepay transaction should reference original transaction")
 	}
+	if result.PrepayTransaction.Date == nil {
+		t.Error("prepay transaction should be dated")
+	}
+}
 
-	if result.RemainingMonths <= 0 {
-		t.Error("should have remaining months")
+func TestPrepayTransaction_FutureStartCountsAllInstallments(t *testing.T) {
+	repo := newMockRepository()
+	svc := newTestService(repo)
+
+	// Starts in 3 months, ends in 5 months: 3 installments, none paid (F3).
+	startDate := monthsAgo(0).AddDate(0, 3, 0)
+	endDate := monthsAgo(0).AddDate(0, 5, 0)
+
+	original := &model.Transaction{
+		ID:          1,
+		IsRecurring: true,
+		Amount:      500.00,
+		Type:        "expense",
+		StartDate:   &startDate,
+		EndDate:     &endDate,
+	}
+	repo.transactions[1] = original
+
+	result, err := svc.PrepayTransaction(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
 	}
 
-	expectedAmount := original.Amount * float64(result.RemainingMonths)
-	if result.PrepaidAmount != expectedAmount {
-		t.Errorf("expected prepaid amount %v, got %v", expectedAmount, result.PrepaidAmount)
+	if result.RemainingMonths != 3 {
+		t.Errorf("expected 3 remaining months for a 3-installment future plan, got %d", result.RemainingMonths)
+	}
+	if result.PrepaidAmount != 1500 {
+		t.Errorf("expected prepaid amount 1500, got %v", result.PrepaidAmount)
+	}
+	if !original.EndDate.Equal(endDate) {
+		t.Errorf("original end_date must not change, got %v", original.EndDate)
 	}
 }
 
 func TestPrepayTransaction_NotRecurring(t *testing.T) {
 	repo := newMockRepository()
-	svc := NewTransactionsService(repo)
+	svc := newTestService(repo)
 
 	original := &model.Transaction{
 		ID:          1,
@@ -490,9 +619,9 @@ func TestPrepayTransaction_NotRecurring(t *testing.T) {
 
 func TestPrepayTransaction_NoEndDate(t *testing.T) {
 	repo := newMockRepository()
-	svc := NewTransactionsService(repo)
+	svc := newTestService(repo)
 
-	startDate := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	startDate := monthsAgo(3)
 
 	original := &model.Transaction{
 		ID:          1,
@@ -516,9 +645,9 @@ func TestPrepayTransaction_NoEndDate(t *testing.T) {
 
 func TestPrepayTransaction_NoStartDate(t *testing.T) {
 	repo := newMockRepository()
-	svc := NewTransactionsService(repo)
+	svc := newTestService(repo)
 
-	endDate := time.Date(2026, 10, 1, 0, 0, 0, 0, time.UTC)
+	endDate := monthsAgo(0).AddDate(0, 3, 0)
 
 	original := &model.Transaction{
 		ID:          1,
@@ -542,10 +671,10 @@ func TestPrepayTransaction_NoStartDate(t *testing.T) {
 
 func TestPrepayTransaction_AlreadyEnded(t *testing.T) {
 	repo := newMockRepository()
-	svc := NewTransactionsService(repo)
+	svc := newTestService(repo)
 
-	startDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	endDate := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	startDate := monthsAgo(8)
+	endDate := monthsAgo(2)
 
 	original := &model.Transaction{
 		ID:          1,
@@ -567,9 +696,36 @@ func TestPrepayTransaction_AlreadyEnded(t *testing.T) {
 	}
 }
 
+func TestPrepayTransaction_EndsThisMonthHasNothingLeft(t *testing.T) {
+	repo := newMockRepository()
+	svc := newTestService(repo)
+
+	startDate := monthsAgo(5)
+	endDate := monthsAgo(0)
+
+	original := &model.Transaction{
+		ID:          1,
+		IsRecurring: true,
+		Amount:      500.00,
+		Type:        "expense",
+		StartDate:   &startDate,
+		EndDate:     &endDate,
+	}
+	repo.transactions[1] = original
+
+	_, err := svc.PrepayTransaction(context.Background(), 1)
+	if err == nil {
+		t.Fatal("expected error when the current month is the last installment")
+	}
+
+	if err.Error() != "no remaining installments to prepay" {
+		t.Errorf("expected 'no remaining installments to prepay' error, got %v", err)
+	}
+}
+
 func TestPrepayTransaction_NotFound(t *testing.T) {
 	repo := newMockRepository()
-	svc := NewTransactionsService(repo)
+	svc := newTestService(repo)
 
 	_, err := svc.PrepayTransaction(context.Background(), 999)
 	if err == nil {
@@ -583,10 +739,10 @@ func TestPrepayTransaction_NotFound(t *testing.T) {
 
 func TestPrepayTransaction_DescriptionFormat(t *testing.T) {
 	repo := newMockRepository()
-	svc := NewTransactionsService(repo)
+	svc := newTestService(repo)
 
-	startDate := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	endDate := time.Date(2026, 12, 1, 0, 0, 0, 0, time.UTC)
+	startDate := monthsAgo(4)
+	endDate := monthsAgo(0).AddDate(0, 4, 0)
 	desc := "Parcela Geladeira"
 
 	original := &model.Transaction{
@@ -610,9 +766,8 @@ func TestPrepayTransaction_DescriptionFormat(t *testing.T) {
 		t.Fatal("prepay transaction should have description")
 	}
 
-	expectedDescPrefix := "Adiantamento de"
-	if len(*result.PrepayTransaction.Description) < len(expectedDescPrefix) {
-		t.Errorf("description should start with '%s'", expectedDescPrefix)
+	if !strings.HasPrefix(*result.PrepayTransaction.Description, "Adiantamento de") {
+		t.Errorf("description should start with 'Adiantamento de', got %q", *result.PrepayTransaction.Description)
 	}
 }
 
@@ -620,7 +775,7 @@ func TestPrepayTransaction_DescriptionFormat(t *testing.T) {
 
 func TestGetAverageByCategory_IncludesRecurring(t *testing.T) {
 	repo := newMockRepository()
-	svc := NewTransactionsService(repo)
+	svc := newTestService(repo)
 
 	catID := uint(5)
 	startDate := time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC)
@@ -634,7 +789,7 @@ func TestGetAverageByCategory_IncludesRecurring(t *testing.T) {
 		{CategoryID: &catID, CategoryName: "Eletrodomestics", Amount: 500.0, StartDate: &recurringStart, EndDate: nil},
 	}
 
-	result, err := svc.GetAverageByCategory(context.Background(), &startDate, &endDate)
+	result, _, err := svc.GetAverageByCategory(context.Background(), &startDate, &endDate)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -659,11 +814,16 @@ func TestGetAverageByCategory_IncludesRecurring(t *testing.T) {
 	if entry.Average != expectedAverage {
 		t.Errorf("expected Average %.2f, got %.2f", expectedAverage, entry.Average)
 	}
+
+	// No income in range → no percent_of_income
+	if entry.PercentOfIncome != nil {
+		t.Errorf("expected nil PercentOfIncome without income, got %v", *entry.PercentOfIncome)
+	}
 }
 
 func TestGetAverageByCategory_MixesRecurringAndNonRecurring(t *testing.T) {
 	repo := newMockRepository()
-	svc := NewTransactionsService(repo)
+	svc := newTestService(repo)
 
 	catID := uint(5)
 	startDate := time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC)
@@ -680,7 +840,7 @@ func TestGetAverageByCategory_MixesRecurringAndNonRecurring(t *testing.T) {
 		{CategoryID: &catID, CategoryName: "Eletrodomestics", Amount: 500.0, StartDate: &recurringStart, EndDate: nil},
 	}
 
-	result, err := svc.GetAverageByCategory(context.Background(), &startDate, &endDate)
+	result, _, err := svc.GetAverageByCategory(context.Background(), &startDate, &endDate)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -701,9 +861,47 @@ func TestGetAverageByCategory_MixesRecurringAndNonRecurring(t *testing.T) {
 	}
 }
 
+func TestGetAverageByCategory_PercentOfIncome(t *testing.T) {
+	repo := newMockRepository()
+	svc := newTestService(repo)
+
+	catID := uint(5)
+	startDate := time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC) // 6 months
+
+	repo.nonRecurringSums = []repository.CategoryExpenseSummary{
+		{CategoryID: &catID, CategoryName: "Housing", TotalSpent: 3000.0},
+	}
+	// Income: R$1,000 one-off + R$1,500/month recurring salary over all 6
+	// months = R$10,000 total.
+	repo.incomeTotal = 1000.0
+	salaryStart := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	repo.recurringIncomes = []repository.RecurringAmount{
+		{Amount: 1500.0, StartDate: &salaryStart, EndDate: nil},
+	}
+
+	result, totalIncome, err := svc.GetAverageByCategory(context.Background(), &startDate, &endDate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if totalIncome != 10000.0 {
+		t.Errorf("expected total income 10000, got %v", totalIncome)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 category, got %d", len(result))
+	}
+	if result[0].PercentOfIncome == nil {
+		t.Fatal("expected percent_of_income to be set")
+	}
+	if math.Abs(*result[0].PercentOfIncome-30.0) > 0.001 {
+		t.Errorf("expected percent_of_income 30, got %v", *result[0].PercentOfIncome)
+	}
+}
+
 func TestGetAverageByCategory_RecurringEndedBeforeRange(t *testing.T) {
 	repo := newMockRepository()
-	svc := NewTransactionsService(repo)
+	svc := newTestService(repo)
 
 	catID := uint(5)
 	startDate := time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC)
@@ -716,7 +914,7 @@ func TestGetAverageByCategory_RecurringEndedBeforeRange(t *testing.T) {
 		{CategoryID: &catID, CategoryName: "Eletrodomestics", Amount: 500.0, StartDate: &recurringStart, EndDate: &recurringEnd},
 	}
 
-	result, err := svc.GetAverageByCategory(context.Background(), &startDate, &endDate)
+	result, _, err := svc.GetAverageByCategory(context.Background(), &startDate, &endDate)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -724,5 +922,37 @@ func TestGetAverageByCategory_RecurringEndedBeforeRange(t *testing.T) {
 	// Transaction ended before range, should contribute nothing
 	if len(result) != 0 {
 		t.Errorf("expected 0 categories, got %d (transaction ended before range)", len(result))
+	}
+}
+
+func TestGetAverageByCategory_DefaultRangeExcludesCurrentMonth(t *testing.T) {
+	repo := newMockRepository()
+	svc := newTestService(repo)
+
+	catID := uint(5)
+	// Recurring R$100/month, active from 4 months ago with no end. Without an
+	// explicit end date the range must stop at the last complete month, so
+	// the current month contributes neither spend nor a denominator slot.
+	recurringStart := monthsAgo(4)
+	repo.recurringExpenses = []repository.RecurringCategoryExpense{
+		{CategoryID: &catID, CategoryName: "Streaming", Amount: 100.0, StartDate: &recurringStart, EndDate: nil},
+	}
+	earliest := recurringStart
+	repo.earliestDate = &earliest
+
+	result, _, err := svc.GetAverageByCategory(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 category, got %d", len(result))
+	}
+
+	// 4 complete months (monthsAgo(4) .. monthsAgo(1)) × R$100 / 4 = R$100.
+	if result[0].TotalSpent != 400 {
+		t.Errorf("expected TotalSpent 400, got %v", result[0].TotalSpent)
+	}
+	if result[0].Average != 100 {
+		t.Errorf("expected Average 100, got %v", result[0].Average)
 	}
 }


### PR DESCRIPTION
## Summary

This PR introduces transaction shape validation to enforce the recurring-transaction invariant (recurring rows are schedules with `start_date` and monthly frequency; one-offs are dated rows with no schedule fields), adds timezone-aware month bucketing for reports, and expands the service layer to support income calculations and per-type date ranges.

## Key Changes

- **Transaction Shape Validation**: Added `validateTransactionShape()` and `normalizeTransactionShape()` functions to enforce and heal the recurring-transaction invariant. `CreateTransaction()` now validates shape and defaults recurring frequency to monthly; `UpdateTransaction()` normalizes shape before validation to handle legacy data.

- **Timezone Support**: Introduced `ReportingConfig.Timezone` and threaded `*time.Location` through the repository and service layers. All month/day bucketing now uses the reporting timezone instead of UTC, ensuring transactions are assigned to the correct calendar month in the user's local time.

- **Per-Type Date Ranges in Averages**: `GetAverageByType()` now computes each transaction type's average over its own active range (earliest data to last complete month), rather than a global range. Types with data only in the current month fall back to reporting the current month's total.

- **Income Calculations**: Added `FindIncomeTotalInRange()` and `FindRecurringIncomesInRange()` repository methods to support income-based reporting. `GetAverageByCategory()` now returns a third value (`float64` total income) and includes optional `PercentOfIncome` in category summaries.

- **Repository Refactoring**: 
  - Extracted `periodCondition()` helper to unify date-range filtering for one-off and recurring transactions.
  - Added `SumAllWithFilters()` to compute transaction totals matching filter criteria.
  - Removed unused methods: `FindByType()`, `FindRecurring()`, `FindByCategory()`, `PrepayTransaction()`.

- **Handler Updates**: 
  - `GetTransactionByID()` now uses timezone-aware `computeTotalPaid()` and `computeTotalLeft()` with the current month counting as paid (F4 convention).
  - `GetTransactions()` now returns the sum of filtered transactions from the repository instead of computing it in-memory.
  - Added `respondTransactionError()` helper to map `ErrInvalidTransaction` to HTTP 400.
  - Date query parameters are now parsed in the reporting timezone and converted to half-open intervals.

- **Test Expansion**: Added comprehensive tests for transaction shape validation, recurring frequency defaults, update normalization, and per-type average calculations. Added `transaction_handler_test.go` with tests for `computeTotalPaid()` and `computeTotalLeft()` covering edge cases (mid-schedule, future start, no end date, etc.).

- **Database Migration**: Added `20260703_frequency_monthly_enum.sql` to create a `transaction_frequency` enum type and normalize legacy frequency values to 'monthly'.

## Notable Implementation Details

- The `InclusiveMonthCount()` and `ExclusiveMonthCount()` functions are now exported (capitalized) for use in tests and handlers.
- `MonthStart()` normalizes a time to the first instant of its calendar month in UTC, used throughout for consistent month boundaries.
- The `periodCondition()` method handles both one-off (by `date` timestamp) and recurring (by `start_date`/`end_date` schedule overlap) transactions in a single WHERE clause.
- Recurring schedules with no `end_date` are treated as open-ended; `computeTotalLeft()` returns `nil` for such schedules.
- The current month is always counted as paid for recurring transactions, ensuring `paid + left` covers the whole schedule when both are known.

https://claude.ai/code/session_01HVomed5rC3T2mnT5GCRbZY