### PR TITLE
Metrics fixes: trailing-window averages, required category, month projection (M1, M3, M6, M7)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -150,6 +150,7 @@ func setupRouter(cfg *config.Config, logger *slog.Logger, transactionHandler *ha
 			transactions.GET("/biggest", transactionHandler.GetBiggestTransactions)
 			transactions.GET("/average/by-type", transactionHandler.GetAverageByType)
 			transactions.GET("/average/by-category", transactionHandler.GetAverageByCategory)
+			transactions.GET("/projections/current-month", transactionHandler.GetCurrentMonthProjection)
 		}
 
 		categories := v1.Group("/categories")

--- a/internal/handler/transaction_handler.go
+++ b/internal/handler/transaction_handler.go
@@ -116,9 +116,16 @@ func (h *TransactionHandler) CreateTransaction(c *gin.Context) {
 		req.Origin = "web"
 	}
 
+	if req.CategoryID == nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "category_id is required",
+		})
+		return
+	}
+
 	transaction := &model.Transaction{
 		IsRecurring:   req.IsRecurring,
-		CategoryID:    req.CategoryID,
+		CategoryID:    *req.CategoryID,
 		SubcategoryID: req.SubcategoryID,
 		CreatedById:   req.CreatedById,
 		Amount:      req.Amount,
@@ -374,13 +381,12 @@ func (h *TransactionHandler) GetTransactions(c *gin.Context) {
 
 	var transactions []model.Transaction
 	var total int64
-	var sum float64
 	var err error
 
 	if currentMonth || len(categoryIDs) > 0 || searchQuery != "" || startDate != nil || endDate != nil || transactionType != "" {
-		transactions, total, sum, err = h.transactionService.GetTransactionsWithFilters(c.Request.Context(), currentMonth, categoryIDs, searchQuery, startDate, endDate, transactionType, limit, offset)
+		transactions, total, err = h.transactionService.GetTransactionsWithFilters(c.Request.Context(), currentMonth, categoryIDs, searchQuery, startDate, endDate, transactionType, limit, offset)
 	} else {
-		transactions, total, sum, err = h.transactionService.GetTransactions(c.Request.Context(), limit, offset)
+		transactions, total, err = h.transactionService.GetTransactions(c.Request.Context(), limit, offset)
 	}
 
 	if err != nil {
@@ -397,7 +403,6 @@ func (h *TransactionHandler) GetTransactions(c *gin.Context) {
 		"total":        total,
 		"limit":        limit,
 		"offset":       offset,
-		"sum":          sum,
 	})
 }
 
@@ -515,7 +520,7 @@ func (h *TransactionHandler) UpdateTransaction(c *gin.Context) {
 		transaction.IsRecurring = *req.IsRecurring
 	}
 	if req.CategoryID != nil {
-		transaction.CategoryID = req.CategoryID
+		transaction.CategoryID = *req.CategoryID
 	}
 	if req.SubcategoryID != nil {
 		transaction.SubcategoryID = req.SubcategoryID
@@ -794,7 +799,19 @@ func (h *TransactionHandler) GetTransactionsByCategories(c *gin.Context) {
 }
 
 func (h *TransactionHandler) GetAverageByType(c *gin.Context) {
-	result, err := h.transactionService.GetAverageByType(c.Request.Context())
+	window := 0
+	if w := c.Query("window"); w != "" {
+		parsed, err := strconv.Atoi(w)
+		if err != nil || parsed < 1 {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "invalid window: must be a positive number of months",
+			})
+			return
+		}
+		window = parsed
+	}
+
+	result, err := h.transactionService.GetAverageByType(c.Request.Context(), window)
 
 	if err != nil {
 		status := http.StatusInternalServerError
@@ -809,6 +826,19 @@ func (h *TransactionHandler) GetAverageByType(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"averageByType": result,
 	})
+}
+
+func (h *TransactionHandler) GetCurrentMonthProjection(c *gin.Context) {
+	projection, err := h.transactionService.GetCurrentMonthProjection(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   "Failed to compute month projection",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, projection)
 }
 
 func (h *TransactionHandler) GetAverageByCategory(c *gin.Context) {

--- a/internal/migrations/20260704_category_required.sql
+++ b/internal/migrations/20260704_category_required.sql
@@ -1,0 +1,45 @@
+-- Category is a required field on every transaction (M3).
+-- This file must stay idempotent: the migration runner re-executes every
+-- file on each boot.
+
+-- Backfill: any transaction without a category moves to a fallback
+-- 'Uncategorized' category (created only if needed).
+DO $$
+    DECLARE
+        fallback_id INTEGER;
+    BEGIN
+        IF EXISTS (SELECT 1 FROM transactions WHERE category_id IS NULL) THEN
+            SELECT id INTO fallback_id
+            FROM categories
+            WHERE name = 'Uncategorized' AND deleted_at IS NULL
+            LIMIT 1;
+
+            IF fallback_id IS NULL THEN
+                INSERT INTO categories (name, description)
+                VALUES ('Uncategorized', 'Fallback for transactions created before category became required')
+                RETURNING id INTO fallback_id;
+            END IF;
+
+            UPDATE transactions SET category_id = fallback_id WHERE category_id IS NULL;
+        END IF;
+    END;
+$$;
+
+ALTER TABLE transactions ALTER COLUMN category_id SET NOT NULL;
+
+-- The FK was ON DELETE SET NULL, which would now violate NOT NULL when a
+-- category row is hard-deleted. RESTRICT makes the dependency explicit.
+DO $$
+    BEGIN
+        IF EXISTS (
+            SELECT 1
+            FROM information_schema.referential_constraints
+            WHERE constraint_name = 'fk_category_id'
+              AND delete_rule = 'SET NULL'
+        ) THEN
+            ALTER TABLE transactions DROP CONSTRAINT fk_category_id;
+            ALTER TABLE transactions ADD CONSTRAINT fk_category_id
+                FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE RESTRICT;
+        END IF;
+    END;
+$$;

--- a/internal/model/transactions.go
+++ b/internal/model/transactions.go
@@ -11,7 +11,7 @@ type Transaction struct {
 	MigratedID    *uint          `gorm:"column:migrated_id" json:"migrated_id"`
 	CreatedById   uint           `gorm:"column:created_by_id" json:"created_by_id"`
 	IsRecurring   bool           `gorm:"not null;default:false" json:"is_recurring"`
-	CategoryID    *uint          `gorm:"column:category_id" json:"category_id"`
+	CategoryID    uint           `gorm:"column:category_id;not null" json:"category_id"`
 	SubcategoryID *uint          `gorm:"column:subcategory_id" json:"subcategory_id"`
 	Subcategory   *Subcategory   `gorm:"foreignKey:SubcategoryID" json:"subcategory,omitempty"`
 	LocationID    *uint          `gorm:"column:location_id" json:"location_id"`

--- a/internal/repository/transactions_repository.go
+++ b/internal/repository/transactions_repository.go
@@ -49,7 +49,6 @@ type TransactionsRepository interface {
 	CountAll() (int64, error)
 	FindAllWithFilters(currentMonth bool, categoryIDs []uint, searchQuery string, startDate, endDate *time.Time, transactionType string, limit, offset int) ([]model.Transaction, error)
 	CountAllWithFilters(currentMonth bool, categoryIDs []uint, searchQuery string, startDate, endDate *time.Time, transactionType string) (int64, error)
-	SumAllWithFilters(currentMonth bool, categoryIDs []uint, searchQuery string, startDate, endDate *time.Time, transactionType string) (float64, error)
 	FindBiggest(month, year int) ([]model.Transaction, error)
 	FindLatest() ([]model.Transaction, error)
 	Update(transaction *model.Transaction) error
@@ -61,6 +60,8 @@ type TransactionsRepository interface {
 	FindRecurringExpensesInRange(startDate, endDate *time.Time) ([]RecurringCategoryExpense, error)
 	FindIncomeTotalInRange(startDate, endDate *time.Time) (float64, error)
 	FindRecurringIncomesInRange(startDate, endDate *time.Time) ([]RecurringAmount, error)
+	FindCurrentMonthRecurringExpenseTotal() (float64, error)
+	FindMonthToDateOneOffExpenseTotal() (float64, error)
 	FindCurrentMonthTotalByType(transactionType string) (float64, error)
 	FindCurrentMonthTotalByTypeAndCategory(transactionType string, categoryID uint) (float64, error)
 	FindNonRecurringMonthlyTotalsByType() ([]MonthlyTypeTotal, error)
@@ -197,13 +198,47 @@ func (r *transactionsRepository) CountAllWithFilters(currentMonth bool, category
 	return count, err
 }
 
-func (r *transactionsRepository) SumAllWithFilters(currentMonth bool, categoryIDs []uint, searchQuery string, startDate, endDate *time.Time, transactionType string) (float64, error) {
+// FindCurrentMonthRecurringExpenseTotal sums the monthly amounts of every
+// recurring expense schedule active in the current month.
+func (r *transactionsRepository) FindCurrentMonthRecurringExpenseTotal() (float64, error) {
+	now := time.Now().In(r.loc)
+	start, end := monthBounds(now.Year(), now.Month(), r.loc)
+
 	var result struct {
 		Total float64 `gorm:"column:total"`
 	}
-	err := r.buildFilterQuery(currentMonth, categoryIDs, searchQuery, startDate, endDate, transactionType).
-		Select("COALESCE(SUM(amount), 0) as total").
-		Scan(&result).Error
+	err := r.db.Raw(`
+		SELECT COALESCE(SUM(amount), 0) as total
+		FROM transactions
+		WHERE type = 'expense'
+		  AND is_recurring = true
+		  AND deleted_at IS NULL
+		  AND start_date < ?
+		  AND (end_date IS NULL OR end_date >= ?)
+	`, end.Format("2006-01-02"), start.Format("2006-01-02")).Scan(&result).Error
+	return result.Total, err
+}
+
+// FindMonthToDateOneOffExpenseTotal sums one-off expenses from the start of
+// the current month through the end of today (prepay lumps excluded).
+func (r *transactionsRepository) FindMonthToDateOneOffExpenseTotal() (float64, error) {
+	now := time.Now().In(r.loc)
+	start, _ := monthBounds(now.Year(), now.Month(), r.loc)
+	endOfToday := time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, r.loc)
+
+	var result struct {
+		Total float64 `gorm:"column:total"`
+	}
+	err := r.db.Raw(`
+		SELECT COALESCE(SUM(amount), 0) as total
+		FROM transactions
+		WHERE type = 'expense'
+		  AND is_recurring = false
+		  AND prepaid_from_id IS NULL
+		  AND deleted_at IS NULL
+		  AND date >= ?
+		  AND date < ?
+	`, start, endOfToday).Scan(&result).Error
 	return result.Total, err
 }
 

--- a/internal/service/transactions_service.go
+++ b/internal/service/transactions_service.go
@@ -14,6 +14,11 @@ import (
 // MonthlyFrequency is the only supported recurrence frequency.
 const MonthlyFrequency = "monthly"
 
+// DefaultAverageWindowMonths is the trailing window used for monthly
+// averages when the caller doesn't specify one. All-time averages converge
+// to a flat line and stop reflecting current behavior.
+const DefaultAverageWindowMonths = 6
+
 // ErrInvalidTransaction is the sentinel wrapped by every transaction-shape
 // validation error, so handlers can map them to 400 with errors.Is.
 var ErrInvalidTransaction = errors.New("invalid transaction")
@@ -36,11 +41,12 @@ type TransactionPercentages struct {
 
 type TransactionsService interface {
 	CreateTransaction(ctx context.Context, transaction *model.Transaction) error
-	GetAverageByType(ctx context.Context) ([]AverageType, error)
+	GetAverageByType(ctx context.Context, windowMonths int) ([]AverageType, error)
 	GetAverageByCategory(ctx context.Context, startDate, endDate *time.Time) ([]AverageByCategory, float64, error)
+	GetCurrentMonthProjection(ctx context.Context) (*MonthProjection, error)
 	GetTransactionByID(ctx context.Context, id uint) (*model.Transaction, error)
-	GetTransactions(ctx context.Context, limit, offset int) ([]model.Transaction, int64, float64, error)
-	GetTransactionsWithFilters(ctx context.Context, currentMonth bool, categoryIDs []uint, searchQuery string, startDate, endDate *time.Time, transactionType string, limit, offset int) ([]model.Transaction, int64, float64, error)
+	GetTransactions(ctx context.Context, limit, offset int) ([]model.Transaction, int64, error)
+	GetTransactionsWithFilters(ctx context.Context, currentMonth bool, categoryIDs []uint, searchQuery string, startDate, endDate *time.Time, transactionType string, limit, offset int) ([]model.Transaction, int64, error)
 	GetLatestTransactions(ctx context.Context) ([]model.Transaction, error)
 	GetBiggestTransactions(ctx context.Context, month, year int) ([]model.Transaction, error)
 	UpdateTransaction(ctx context.Context, transaction *model.Transaction) error
@@ -67,6 +73,9 @@ func NewTransactionsService(transactionRepo repository.TransactionsRepository, l
 // recurring rows are schedules (start_date set, no date, monthly frequency),
 // one-offs are dated rows with no schedule fields.
 func validateTransactionShape(t *model.Transaction) error {
+	if t.CategoryID == 0 {
+		return invalidf("category_id is required")
+	}
 	if t.IsRecurring {
 		if t.StartDate == nil {
 			return invalidf("recurring transaction requires start_date")
@@ -121,17 +130,13 @@ func (s *transactionsService) GetTransactionByID(ctx context.Context, id uint) (
 	return s.transactionRepo.FindByID(id)
 }
 
-func (s *transactionsService) GetTransactions(ctx context.Context, limit, offset int) ([]model.Transaction, int64, float64, error) {
+func (s *transactionsService) GetTransactions(ctx context.Context, limit, offset int) ([]model.Transaction, int64, error) {
 	total, err := s.transactionRepo.CountAll()
 	if err != nil {
-		return nil, 0, 0, err
-	}
-	sum, err := s.transactionRepo.SumAllWithFilters(false, nil, "", nil, nil, "")
-	if err != nil {
-		return nil, 0, 0, err
+		return nil, 0, err
 	}
 	transactions, err := s.transactionRepo.FindAll(limit, offset)
-	return transactions, total, sum, err
+	return transactions, total, err
 }
 
 func (s *transactionsService) GetLatestTransactions(ctx context.Context) ([]model.Transaction, error) {
@@ -142,17 +147,13 @@ func (s *transactionsService) GetBiggestTransactions(ctx context.Context, month,
 	return s.transactionRepo.FindBiggest(month, year)
 }
 
-func (s *transactionsService) GetTransactionsWithFilters(ctx context.Context, currentMonth bool, categoryIDs []uint, searchQuery string, startDate, endDate *time.Time, transactionType string, limit, offset int) ([]model.Transaction, int64, float64, error) {
+func (s *transactionsService) GetTransactionsWithFilters(ctx context.Context, currentMonth bool, categoryIDs []uint, searchQuery string, startDate, endDate *time.Time, transactionType string, limit, offset int) ([]model.Transaction, int64, error) {
 	total, err := s.transactionRepo.CountAllWithFilters(currentMonth, categoryIDs, searchQuery, startDate, endDate, transactionType)
 	if err != nil {
-		return nil, 0, 0, err
-	}
-	sum, err := s.transactionRepo.SumAllWithFilters(currentMonth, categoryIDs, searchQuery, startDate, endDate, transactionType)
-	if err != nil {
-		return nil, 0, 0, err
+		return nil, 0, err
 	}
 	transactions, err := s.transactionRepo.FindAllWithFilters(currentMonth, categoryIDs, searchQuery, startDate, endDate, transactionType, limit, offset)
-	return transactions, total, sum, err
+	return transactions, total, err
 }
 
 func (s *transactionsService) UpdateTransaction(ctx context.Context, transaction *model.Transaction) error {
@@ -189,8 +190,15 @@ func MonthStart(t time.Time) time.Time {
 // GetAverageByType computes each type's monthly average over that type's own
 // active range, using only complete months (the in-progress month would
 // dilute the average). Types whose data lives entirely in the current month
-// fall back to reporting the current month's total.
-func (s *transactionsService) GetAverageByType(ctx context.Context) ([]AverageType, error) {
+// fall back to reporting the current month's total. Averages cover a
+// trailing window of the last windowMonths complete months (M1), so the
+// number tracks recent behavior instead of converging to an all-time flat
+// line.
+func (s *transactionsService) GetAverageByType(ctx context.Context, windowMonths int) ([]AverageType, error) {
+	if windowMonths < 1 {
+		windowMonths = DefaultAverageWindowMonths
+	}
+
 	monthlyTotals, err := s.transactionRepo.FindNonRecurringMonthlyTotalsByType()
 	if err != nil {
 		log.Printf("[TransactionsService.GetAverageByType] ERROR: Failed to fetch monthly totals: %v", err)
@@ -206,6 +214,7 @@ func (s *transactionsService) GetAverageByType(ctx context.Context) ([]AverageTy
 	now := time.Now().In(s.loc)
 	currentMonth := MonthStart(now)
 	lastComplete := currentMonth.AddDate(0, -1, 0)
+	windowStart := lastComplete.AddDate(0, -(windowMonths-1), 0)
 
 	type agg struct {
 		total    float64
@@ -231,6 +240,8 @@ func (s *transactionsService) GetAverageByType(ctx context.Context) ([]AverageTy
 	for _, row := range monthlyTotals {
 		m := time.Date(row.Year, time.Month(row.Month), 1, 0, 0, 0, 0, time.UTC)
 		switch {
+		case m.Before(windowStart):
+			// outside the trailing window
 		case m.Before(currentMonth):
 			add(row.Type, row.MonthlySum, m)
 		case m.Equal(currentMonth):
@@ -243,6 +254,9 @@ func (s *transactionsService) GetAverageByType(ctx context.Context) ([]AverageTy
 			continue
 		}
 		startM := MonthStart(*tx.StartDate)
+		if startM.Before(windowStart) {
+			startM = windowStart
+		}
 		endM := lastComplete
 		if tx.EndDate != nil {
 			if e := MonthStart(*tx.EndDate); e.Before(endM) {
@@ -252,7 +266,8 @@ func (s *transactionsService) GetAverageByType(ctx context.Context) ([]AverageTy
 		if !endM.Before(startM) {
 			add(tx.Type, tx.Amount*float64(InclusiveMonthCount(startM, endM)), startM)
 		}
-		activeNow := !startM.After(currentMonth) && (tx.EndDate == nil || !MonthStart(*tx.EndDate).Before(currentMonth))
+		startedByNow := !MonthStart(*tx.StartDate).After(currentMonth)
+		activeNow := startedByNow && (tx.EndDate == nil || !MonthStart(*tx.EndDate).Before(currentMonth))
 		if activeNow {
 			currentOnly[tx.Type] += tx.Amount
 		}
@@ -427,6 +442,46 @@ func (s *transactionsService) GetAverageByCategory(ctx context.Context, startDat
 	return result, incomeTotal, nil
 }
 
+type MonthProjection struct {
+	Month              string  `json:"month"`
+	RecurringCommitted float64 `json:"recurring_committed"`
+	OneOffSpent        float64 `json:"one_off_spent"`
+	ProjectedOneOff    float64 `json:"projected_one_off"`
+	ProjectedTotal     float64 `json:"projected_total"`
+}
+
+// projectMonth extrapolates end-of-month spending: recurring commitments are
+// fixed, one-off spending continues at the month-to-date daily run rate.
+func projectMonth(now time.Time, recurringCommitted, oneOffSpent float64) *MonthProjection {
+	daysInMonth := time.Date(now.Year(), now.Month()+1, 0, 0, 0, 0, 0, now.Location()).Day()
+	elapsedDays := now.Day()
+
+	projectedOneOff := oneOffSpent / float64(elapsedDays) * float64(daysInMonth)
+
+	return &MonthProjection{
+		Month:              now.Format("2006-01"),
+		RecurringCommitted: recurringCommitted,
+		OneOffSpent:        oneOffSpent,
+		ProjectedOneOff:    projectedOneOff,
+		ProjectedTotal:     recurringCommitted + projectedOneOff,
+	}
+}
+
+// GetCurrentMonthProjection estimates where this month's expenses will land
+// (M6): the recurring commitments already known plus one-off spending
+// extrapolated from the month-to-date run rate.
+func (s *transactionsService) GetCurrentMonthProjection(ctx context.Context) (*MonthProjection, error) {
+	recurring, err := s.transactionRepo.FindCurrentMonthRecurringExpenseTotal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch recurring expense total: %w", err)
+	}
+	oneOff, err := s.transactionRepo.FindMonthToDateOneOffExpenseTotal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch month-to-date expense total: %w", err)
+	}
+	return projectMonth(time.Now().In(s.loc), recurring, oneOff), nil
+}
+
 func (s *transactionsService) GetTransactionsByDateRange(ctx context.Context, startDate, endDate time.Time) ([]model.Transaction, error) {
 	return s.transactionRepo.FindByDateRange(startDate, endDate)
 }
@@ -543,8 +598,8 @@ func (s *transactionsService) GetTransactionMonthlyPercentages(ctx context.Conte
 		percentages.TotalMonthPercent = &pct
 	}
 
-	if tx.CategoryID != nil {
-		categoryTotal, err := s.transactionRepo.FindCurrentMonthTotalByTypeAndCategory(tx.Type, *tx.CategoryID)
+	if tx.CategoryID != 0 {
+		categoryTotal, err := s.transactionRepo.FindCurrentMonthTotalByTypeAndCategory(tx.Type, tx.CategoryID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch current month category total: %w", err)
 		}

--- a/internal/service/transactions_service_test.go
+++ b/internal/service/transactions_service_test.go
@@ -22,6 +22,8 @@ type mockTransactionsRepository struct {
 	recurringByType   []repository.RecurringTypeTransaction
 	incomeTotal       float64
 	recurringIncomes  []repository.RecurringAmount
+	recurringMonthly  float64
+	oneOffMonthToDate float64
 }
 
 func newMockRepository() *mockTransactionsRepository {
@@ -63,8 +65,12 @@ func (m *mockTransactionsRepository) CountAllWithFilters(currentMonth bool, cate
 	return 0, nil
 }
 
-func (m *mockTransactionsRepository) SumAllWithFilters(currentMonth bool, categoryIDs []uint, searchQuery string, startDate, endDate *time.Time, transactionType string) (float64, error) {
-	return 0, nil
+func (m *mockTransactionsRepository) FindCurrentMonthRecurringExpenseTotal() (float64, error) {
+	return m.recurringMonthly, nil
+}
+
+func (m *mockTransactionsRepository) FindMonthToDateOneOffExpenseTotal() (float64, error) {
+	return m.oneOffMonthToDate, nil
 }
 
 func (m *mockTransactionsRepository) FindBiggest(month, year int) ([]model.Transaction, error) {
@@ -238,40 +244,45 @@ func TestTransactionShapeValidation(t *testing.T) {
 	}{
 		{
 			name: "valid one-off",
-			tx:   model.Transaction{Date: &now, Amount: 10, Type: "expense"},
+			tx:   model.Transaction{Date: &now, Amount: 10, Type: "expense", CategoryID: 1},
 		},
 		{
 			name: "valid recurring",
-			tx:   model.Transaction{IsRecurring: true, StartDate: &start, EndDate: &end, Amount: 10, Type: "expense"},
+			tx:   model.Transaction{IsRecurring: true, StartDate: &start, EndDate: &end, Amount: 10, Type: "expense", CategoryID: 1},
+		},
+		{
+			name:    "missing category",
+			tx:      model.Transaction{Date: &now, Amount: 10, Type: "expense"},
+			wantErr: "category_id is required",
 		},
 		{
 			name:    "recurring without start_date",
-			tx:      model.Transaction{IsRecurring: true, EndDate: &end},
+			tx:      model.Transaction{IsRecurring: true, EndDate: &end, CategoryID: 1},
 			wantErr: "start_date",
 		},
 		{
 			name:    "recurring with date",
-			tx:      model.Transaction{IsRecurring: true, StartDate: &start, Date: &now},
+			tx:      model.Transaction{IsRecurring: true, StartDate: &start, Date: &now, CategoryID: 1},
 			wantErr: "must not have date",
 		},
 		{
 			name:    "recurring with non-monthly frequency",
-			tx:      model.Transaction{IsRecurring: true, StartDate: &start, Frequency: &weekly},
+			tx:      model.Transaction{IsRecurring: true, StartDate: &start, Frequency: &weekly, CategoryID: 1},
 			wantErr: "monthly",
 		},
 		{
 			name:    "recurring with end before start",
-			tx:      model.Transaction{IsRecurring: true, StartDate: &end, EndDate: &start, Frequency: &monthly},
+			tx:      model.Transaction{IsRecurring: true, StartDate: &end, EndDate: &start, Frequency: &monthly, CategoryID: 1},
 			wantErr: "end_date must not be before start_date",
 		},
 		{
 			name:    "one-off without date",
-			tx:      model.Transaction{},
+			tx:      model.Transaction{CategoryID: 1},
 			wantErr: "requires date",
 		},
 		{
 			name:    "one-off with schedule fields",
-			tx:      model.Transaction{Date: &now, EndDate: &end},
+			tx:      model.Transaction{Date: &now, EndDate: &end, CategoryID: 1},
 			wantErr: "must not have start_date, end_date or frequency",
 		},
 	}
@@ -307,7 +318,7 @@ func TestCreateTransaction_DefaultsRecurringFrequencyToMonthly(t *testing.T) {
 	svc := newTestService(repo)
 
 	start := monthsAgo(1)
-	tx := model.Transaction{IsRecurring: true, StartDate: &start, Amount: 10, Type: "expense"}
+	tx := model.Transaction{IsRecurring: true, StartDate: &start, Amount: 10, Type: "expense", CategoryID: 1}
 	if err := svc.CreateTransaction(context.Background(), &tx); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -326,7 +337,7 @@ func TestUpdateTransaction_NormalizesShape(t *testing.T) {
 	weekly := "weekly"
 
 	// Legacy corrupted row: one-off carrying schedule fields (pre-F1 web data).
-	legacy := model.Transaction{ID: 1, Date: &now, EndDate: &end, Frequency: &weekly, Amount: 10, Type: "expense"}
+	legacy := model.Transaction{ID: 1, Date: &now, EndDate: &end, Frequency: &weekly, Amount: 10, Type: "expense", CategoryID: 1}
 	if err := svc.UpdateTransaction(context.Background(), &legacy); err != nil {
 		t.Fatalf("expected legacy row to be healed, got %v", err)
 	}
@@ -335,7 +346,7 @@ func TestUpdateTransaction_NormalizesShape(t *testing.T) {
 	}
 
 	// Flip to recurring: date must be cleared, frequency coerced to monthly.
-	rec := model.Transaction{ID: 2, IsRecurring: true, Date: &now, StartDate: &start, Frequency: &weekly, Amount: 10, Type: "expense"}
+	rec := model.Transaction{ID: 2, IsRecurring: true, Date: &now, StartDate: &start, Frequency: &weekly, Amount: 10, Type: "expense", CategoryID: 1}
 	if err := svc.UpdateTransaction(context.Background(), &rec); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -347,7 +358,7 @@ func TestUpdateTransaction_NormalizesShape(t *testing.T) {
 	}
 
 	// Flip to recurring without start_date must fail.
-	bad := model.Transaction{ID: 3, IsRecurring: true, Date: &now, Amount: 10, Type: "expense"}
+	bad := model.Transaction{ID: 3, IsRecurring: true, Date: &now, Amount: 10, Type: "expense", CategoryID: 1}
 	if err := svc.UpdateTransaction(context.Background(), &bad); !errors.Is(err, ErrInvalidTransaction) {
 		t.Errorf("expected ErrInvalidTransaction, got %v", err)
 	}
@@ -372,7 +383,7 @@ func TestGetAverageByType_PerTypeRanges(t *testing.T) {
 		{Type: "expense", Year: expenseMonth.Year(), Month: int(expenseMonth.Month()), MonthlySum: 200},
 	}
 
-	result, err := svc.GetAverageByType(context.Background())
+	result, err := svc.GetAverageByType(context.Background(), 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -406,7 +417,7 @@ func TestGetAverageByType_ExcludesCurrentMonth(t *testing.T) {
 		{Type: "expense", Year: current.Year(), Month: int(current.Month()), MonthlySum: 9999},
 	}
 
-	result, err := svc.GetAverageByType(context.Background())
+	result, err := svc.GetAverageByType(context.Background(), 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -427,7 +438,7 @@ func TestGetAverageByType_CurrentMonthOnlyFallback(t *testing.T) {
 		{Type: "expense", Year: current.Year(), Month: int(current.Month()), MonthlySum: 300},
 	}
 
-	result, err := svc.GetAverageByType(context.Background())
+	result, err := svc.GetAverageByType(context.Background(), 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -450,7 +461,7 @@ func TestGetAverageByType_RecurringExpansion(t *testing.T) {
 		{Type: "expense", Amount: 20, StartDate: &start, EndDate: &end},
 	}
 
-	result, err := svc.GetAverageByType(context.Background())
+	result, err := svc.GetAverageByType(context.Background(), 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -481,7 +492,7 @@ func TestGetAverageByType_MixedRecurringAndNon(t *testing.T) {
 		{Type: "expense", Amount: 20, StartDate: &recurringStart, EndDate: &recurringEnd},
 	}
 
-	result, err := svc.GetAverageByType(context.Background())
+	result, err := svc.GetAverageByType(context.Background(), 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -495,11 +506,105 @@ func TestGetAverageByType_MixedRecurringAndNon(t *testing.T) {
 	}
 }
 
+func TestGetAverageByType_WindowClipsOldMonths(t *testing.T) {
+	repo := newMockRepository()
+	svc := newTestService(repo)
+
+	// Spending 8 months ago is outside a 6-month trailing window (M1) but
+	// inside a 12-month one.
+	oldMonth := monthsAgo(8)
+	recentMonth := monthsAgo(2)
+	repo.monthlyTotals = []repository.MonthlyTypeTotal{
+		{Type: "expense", Year: oldMonth.Year(), Month: int(oldMonth.Month()), MonthlySum: 900},
+		{Type: "expense", Year: recentMonth.Year(), Month: int(recentMonth.Month()), MonthlySum: 300},
+	}
+
+	narrow, err := svc.GetAverageByType(context.Background(), 6)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Only the recent month counts, averaged over its own in-window range.
+	expectedNarrow := 300.0 / float64(InclusiveMonthCount(recentMonth, lastCompleteMonth()))
+	if math.Abs(narrow[0].Average-expectedNarrow) > 0.001 {
+		t.Errorf("window=6 average = %v, expected %v (old month excluded)", narrow[0].Average, expectedNarrow)
+	}
+
+	wide, err := svc.GetAverageByType(context.Background(), 12)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expectedWide := (900.0 + 300.0) / float64(InclusiveMonthCount(oldMonth, lastCompleteMonth()))
+	if math.Abs(wide[0].Average-expectedWide) > 0.001 {
+		t.Errorf("window=12 average = %v, expected %v (old month included)", wide[0].Average, expectedWide)
+	}
+}
+
+func TestGetAverageByType_WindowClipsRecurringStart(t *testing.T) {
+	repo := newMockRepository()
+	svc := newTestService(repo)
+
+	// Open-ended recurring $100/month running for 20 months: a 6-month
+	// window must average exactly $100, not dilute or accumulate.
+	start := monthsAgo(20)
+	repo.recurringByType = []repository.RecurringTypeTransaction{
+		{Type: "expense", Amount: 100, StartDate: &start, EndDate: nil},
+	}
+
+	result, err := svc.GetAverageByType(context.Background(), 6)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 type, got %d", len(result))
+	}
+	if math.Abs(result[0].Average-100) > 0.001 {
+		t.Errorf("expected average 100 over the window, got %v", result[0].Average)
+	}
+}
+
+// ---- projectMonth tests ----
+
+func TestProjectMonth(t *testing.T) {
+	// July 10th: R$500 one-off spent in 10 of 31 days → R$1,550 projected
+	// one-offs; plus R$800 in recurring commitments.
+	now := time.Date(2026, 7, 10, 15, 0, 0, 0, time.UTC)
+	p := projectMonth(now, 800, 500)
+
+	if p.Month != "2026-07" {
+		t.Errorf("expected month 2026-07, got %s", p.Month)
+	}
+	if p.RecurringCommitted != 800 {
+		t.Errorf("expected recurring 800, got %v", p.RecurringCommitted)
+	}
+	if p.OneOffSpent != 500 {
+		t.Errorf("expected one-off spent 500, got %v", p.OneOffSpent)
+	}
+	if math.Abs(p.ProjectedOneOff-1550) > 0.001 {
+		t.Errorf("expected projected one-off 1550, got %v", p.ProjectedOneOff)
+	}
+	if math.Abs(p.ProjectedTotal-2350) > 0.001 {
+		t.Errorf("expected projected total 2350, got %v", p.ProjectedTotal)
+	}
+}
+
+func TestProjectMonth_LastDayEqualsActuals(t *testing.T) {
+	// On the last day of the month the projection is just what was spent.
+	now := time.Date(2026, 6, 30, 23, 0, 0, 0, time.UTC)
+	p := projectMonth(now, 200, 900)
+
+	if math.Abs(p.ProjectedOneOff-900) > 0.001 {
+		t.Errorf("expected projected one-off 900, got %v", p.ProjectedOneOff)
+	}
+	if math.Abs(p.ProjectedTotal-1100) > 0.001 {
+		t.Errorf("expected projected total 1100, got %v", p.ProjectedTotal)
+	}
+}
+
 func TestGetAverageByType_EmptyData(t *testing.T) {
 	repo := newMockRepository()
 	svc := newTestService(repo)
 
-	result, err := svc.GetAverageByType(context.Background())
+	result, err := svc.GetAverageByType(context.Background(), 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
Second batch of audit fixes, covering the approved M items.

## Changes

- **M1 — Trailing-window averages**: `GET /transactions/average/by-type` now averages over the last N complete months (default 6, `?window=N` to override) instead of all-time, so the baseline tracks recent behavior. Per-type ranges and current-month exclusion are preserved; types with data only in the in-progress month still fall back to that month's total.
- **M3 — Category is required**: new idempotent migration `20260704_category_required.sql` backfills `NULL category_id` rows into an `Uncategorized` category (created only if needed), sets the column `NOT NULL`, and switches the FK from `ON DELETE SET NULL` (which would now violate the constraint) to `ON DELETE RESTRICT`. The model uses a non-pointer `CategoryID` and create/update reject missing categories with 400.
- **M6 — Projected end-of-month spend**: new `GET /transactions/projections/current-month` returns recurring commitments plus one-off spending extrapolated at the month-to-date daily run rate (prepay lumps excluded).
- **M7 — `sum` removed** from `GET /transactions`: the page-scoped field was a trap (it caused the broken "% of income" metric) and its only consumer now uses `percent_of_income` from the averages endpoint.

## Verification

- `go build ./... && go vet ./... && go test ./...` green (new tests: window clipping for one-offs and recurring schedules, projection math incl. last-day-of-month, required-category validation).
- Smoke-tested against a live Postgres 16: migration ran on a DB that actually contained a category-less row (backfilled correctly, idempotent on re-run); create-without-category → 400; `?window=3` works, invalid window → 400; list response no longer contains `sum`; projection returned exact expected values.

Merge order note: land this before the `bff` and `financer` PRs — they consume the new projection endpoint and the required-category behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVomed5rC3T2mnT5GCRbZY

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVomed5rC3T2mnT5GCRbZY)_