### PR TITLE
Database hardening: shape constraints, versioned migrations, unique categories (D1, D4, D6, D7)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ArthurWerle/transactions/internal/config"
 	"github.com/ArthurWerle/transactions/internal/handler"
 	"github.com/ArthurWerle/transactions/internal/migrations"
-	"github.com/ArthurWerle/transactions/internal/model"
 	"github.com/ArthurWerle/transactions/internal/repository"
 	"github.com/ArthurWerle/transactions/internal/service"
 	"github.com/gin-contrib/cors"
@@ -39,19 +38,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Run SQL migrations
+	// The versioned SQL migrations are the only schema owner.
 	if err := migrations.RunMigrations(db, logger); err != nil {
 		logger.Error("failed to run migrations", "error", err)
-		os.Exit(1)
-	}
-
-	if err := db.AutoMigrate(
-		&model.Transaction{},
-		&model.Category{},
-		&model.Subcategory{},
-		&model.Location{},
-	); err != nil {
-		logger.Error("failed to auto migrate", "error", err)
 		os.Exit(1)
 	}
 
@@ -216,6 +205,9 @@ func setupDatabase(cfg *config.Config, logger *slog.Logger) (*gorm.DB, error) {
 
 	gormCfg := &gorm.Config{
 		Logger: gormLogger.Default.LogMode(gormLogLevel),
+		// Translate driver errors (e.g. unique violations) into gorm.Err*
+		// sentinels so handlers can map them to proper HTTP statuses.
+		TranslateError: true,
 	}
 
 	db, err := gorm.Open(postgres.Open(cfg.Database.DSN()), gormCfg)

--- a/internal/handler/category_handler.go
+++ b/internal/handler/category_handler.go
@@ -1,12 +1,14 @@
 package handler
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/ArthurWerle/transactions/internal/model"
 	"github.com/ArthurWerle/transactions/internal/service"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 )
 
 type CategoryHandler struct {
@@ -42,6 +44,12 @@ func (h *CategoryHandler) CreateCategory(c *gin.Context) {
 	}
 
 	if err := h.categoryService.CreateCategory(c.Request.Context(), category); err != nil {
+		if errors.Is(err, gorm.ErrDuplicatedKey) {
+			c.JSON(http.StatusConflict, gin.H{
+				"error": "A category with this name already exists",
+			})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error":   "Failed to create category",
 			"details": err.Error(),
@@ -78,7 +86,8 @@ func (h *CategoryHandler) GetCategoryByID(c *gin.Context) {
 }
 
 func (h *CategoryHandler) GetCategories(c *gin.Context) {
-	categories, err := h.categoryService.GetCategories(c.Request.Context())
+	includeDeleted := c.Query("include_deleted") == "true"
+	categories, err := h.categoryService.GetCategories(c.Request.Context(), includeDeleted)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error":   "Failed to fetch categories",
@@ -138,6 +147,12 @@ func (h *CategoryHandler) UpdateCategory(c *gin.Context) {
 	}
 
 	if err := h.categoryService.UpdateCategory(c.Request.Context(), category); err != nil {
+		if errors.Is(err, gorm.ErrDuplicatedKey) {
+			c.JSON(http.StatusConflict, gin.H{
+				"error": "A category with this name already exists",
+			})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error":   "Failed to update category",
 			"details": err.Error(),

--- a/internal/migrations/20260705_transaction_shape_constraints.sql
+++ b/internal/migrations/20260705_transaction_shape_constraints.sql
@@ -1,0 +1,75 @@
+-- D1: enforce the recurring-transaction invariant at the database level.
+-- Repairs run first (including soft-deleted rows, since CHECK constraints
+-- apply to every row), then the constraints are added.
+
+-- One-off rows must not carry schedule fields (legacy pre-F1 web
+-- installments were stored this way; reports always counted them as
+-- one-offs, so clearing the fields preserves reported history).
+UPDATE transactions
+SET start_date = NULL, end_date = NULL, frequency = NULL
+WHERE is_recurring = false
+  AND (start_date IS NOT NULL OR end_date IS NOT NULL OR frequency IS NOT NULL);
+
+-- One-off rows must be dated; fall back to their creation time.
+UPDATE transactions
+SET date = created_at
+WHERE is_recurring = false AND date IS NULL;
+
+-- Recurring rows must have a start; derive from date or creation time.
+UPDATE transactions
+SET start_date = COALESCE(date::date, created_at::date)
+WHERE is_recurring = true AND start_date IS NULL;
+
+-- Recurring rows are schedules, not dated events.
+UPDATE transactions
+SET date = NULL
+WHERE is_recurring = true AND date IS NOT NULL;
+
+-- Recurring rows always carry the (only) frequency.
+UPDATE transactions
+SET frequency = 'monthly'
+WHERE is_recurring = true AND frequency IS NULL;
+
+-- A schedule cannot end before it starts; collapse to a single month.
+UPDATE transactions
+SET end_date = start_date
+WHERE is_recurring = true AND end_date IS NOT NULL AND end_date < start_date;
+
+DO $$
+    BEGIN
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint WHERE conname = 'chk_transactions_shape'
+        ) THEN
+            ALTER TABLE transactions ADD CONSTRAINT chk_transactions_shape CHECK (
+                (is_recurring AND date IS NULL AND start_date IS NOT NULL AND frequency IS NOT NULL)
+                OR
+                (NOT is_recurring AND date IS NOT NULL AND start_date IS NULL AND end_date IS NULL AND frequency IS NULL)
+            );
+        END IF;
+    END;
+$$;
+
+DO $$
+    BEGIN
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint WHERE conname = 'chk_transactions_dates'
+        ) THEN
+            ALTER TABLE transactions ADD CONSTRAINT chk_transactions_dates CHECK (
+                end_date IS NULL OR start_date IS NULL OR end_date >= start_date
+            );
+        END IF;
+    END;
+$$;
+
+-- The API has always rejected non-positive amounts; NOT VALID keeps boot
+-- safe should some ancient row disagree, while still protecting new writes.
+DO $$
+    BEGIN
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint WHERE conname = 'chk_transactions_amount_positive'
+        ) THEN
+            ALTER TABLE transactions ADD CONSTRAINT chk_transactions_amount_positive
+                CHECK (amount > 0) NOT VALID;
+        END IF;
+    END;
+$$;

--- a/internal/migrations/20260706_unique_category_names.sql
+++ b/internal/migrations/20260706_unique_category_names.sql
@@ -1,0 +1,30 @@
+-- D6: category names must be unique (case- and whitespace-insensitive),
+-- mirroring the locations pattern. Duplicate live categories are merged
+-- first: transactions move to the oldest duplicate, the rest are
+-- soft-deleted.
+
+DO $$
+    DECLARE
+        dup RECORD;
+    BEGIN
+        FOR dup IN
+            SELECT min(id) AS keeper, array_agg(id) AS ids
+            FROM categories
+            WHERE deleted_at IS NULL
+            GROUP BY lower(btrim(name))
+            HAVING count(*) > 1
+        LOOP
+            UPDATE transactions
+            SET category_id = dup.keeper
+            WHERE category_id = ANY(dup.ids) AND category_id <> dup.keeper;
+
+            UPDATE categories
+            SET deleted_at = CURRENT_TIMESTAMP
+            WHERE id = ANY(dup.ids) AND id <> dup.keeper;
+        END LOOP;
+    END;
+$$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_categories_normalized_name
+    ON categories (lower(btrim(name)))
+    WHERE deleted_at IS NULL;

--- a/internal/migrations/20260707_transactions_deleted_at_index.sql
+++ b/internal/migrations/20260707_transactions_deleted_at_index.sql
@@ -1,0 +1,4 @@
+-- With AutoMigrate removed (D4), the SQL migrations are the only schema
+-- owner. This index previously came from GORM's soft-delete tag; keeping it
+-- here makes fresh databases match existing ones.
+CREATE INDEX IF NOT EXISTS idx_transactions_deleted_at ON transactions(deleted_at);

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -11,7 +11,29 @@ import (
 //go:embed *.sql
 var migrationFiles embed.FS
 
+// RunMigrations applies each embedded SQL file exactly once, in filename
+// order, recording applied files in schema_migrations. Each file runs inside
+// a transaction together with its version record, so a failed migration
+// leaves no partial state and is retried on the next boot.
 func RunMigrations(db *gorm.DB, logger *slog.Logger) error {
+	if err := db.Exec(`CREATE TABLE IF NOT EXISTS schema_migrations (
+		filename   TEXT PRIMARY KEY,
+		applied_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+	)`).Error; err != nil {
+		logger.Error("failed to create schema_migrations table", "error", err)
+		return err
+	}
+
+	var appliedFiles []string
+	if err := db.Raw("SELECT filename FROM schema_migrations").Scan(&appliedFiles).Error; err != nil {
+		logger.Error("failed to read schema_migrations", "error", err)
+		return err
+	}
+	applied := make(map[string]bool, len(appliedFiles))
+	for _, f := range appliedFiles {
+		applied[f] = true
+	}
+
 	entries, err := migrationFiles.ReadDir(".")
 	if err != nil {
 		logger.Error("failed to read migration directory", "error", err)
@@ -27,20 +49,30 @@ func RunMigrations(db *gorm.DB, logger *slog.Logger) error {
 	sort.Strings(files)
 
 	for _, file := range files {
+		if applied[file] {
+			continue
+		}
+
 		sqlContent, err := migrationFiles.ReadFile(file)
 		if err != nil {
 			logger.Error("failed to read migration file", "file", file, "error", err)
 			return err
 		}
 
-		if err := db.Exec(string(sqlContent)).Error; err != nil {
+		err = db.Transaction(func(tx *gorm.DB) error {
+			if err := tx.Exec(string(sqlContent)).Error; err != nil {
+				return err
+			}
+			return tx.Exec("INSERT INTO schema_migrations (filename) VALUES (?)", file).Error
+		})
+		if err != nil {
 			logger.Error("failed to execute migration", "file", file, "error", err)
 			return err
 		}
 
-		logger.Info("migration executed", "file", file)
+		logger.Info("migration applied", "file", file)
 	}
 
-	logger.Info("all migrations executed successfully")
+	logger.Info("migrations up to date")
 	return nil
 }

--- a/internal/repository/category_repository.go
+++ b/internal/repository/category_repository.go
@@ -8,7 +8,7 @@ import (
 type CategoryRepository interface {
 	Create(category *model.Category) error
 	FindByID(id uint) (*model.Category, error)
-	FindAll() ([]model.Category, error)
+	FindAll(includeDeleted bool) ([]model.Category, error)
 	Update(category *model.Category) error
 	Delete(id uint) error
 }
@@ -34,9 +34,16 @@ func (r *categoryRepository) FindByID(id uint) (*model.Category, error) {
 	return &category, nil
 }
 
-func (r *categoryRepository) FindAll() ([]model.Category, error) {
+// FindAll returns live categories; with includeDeleted it also returns
+// soft-deleted ones (their deleted_at populated), so reporting consumers can
+// label money that belongs to removed categories instead of hiding it.
+func (r *categoryRepository) FindAll(includeDeleted bool) ([]model.Category, error) {
 	var categories []model.Category
-	err := r.db.Order("name ASC").Find(&categories).Error
+	query := r.db
+	if includeDeleted {
+		query = query.Unscoped()
+	}
+	err := query.Order("name ASC").Find(&categories).Error
 	return categories, err
 }
 

--- a/internal/repository/transactions_repository.go
+++ b/internal/repository/transactions_repository.go
@@ -321,7 +321,7 @@ func (r *transactionsRepository) FindExpenseSummaryByCategory(startDate, endDate
 	query := `
 		SELECT
 			t.category_id,
-			c.name as category_name,
+			CASE WHEN c.deleted_at IS NOT NULL THEN c.name || ' (deleted)' ELSE c.name END as category_name,
 			SUM(t.amount) as total_spent
 		FROM transactions t
 		LEFT JOIN categories c ON c.id = t.category_id
@@ -339,7 +339,7 @@ func (r *transactionsRepository) FindExpenseSummaryByCategory(startDate, endDate
 		query += " AND t.date < ?"
 		args = append(args, endDate.AddDate(0, 0, 1))
 	}
-	query += " GROUP BY t.category_id, c.name"
+	query += " GROUP BY t.category_id, c.name, c.deleted_at"
 	err := r.db.Raw(query, args...).Scan(&results).Error
 	return results, err
 }
@@ -349,7 +349,7 @@ func (r *transactionsRepository) FindRecurringExpensesInRange(startDate, endDate
 	query := `
 		SELECT
 			t.category_id,
-			c.name as category_name,
+			CASE WHEN c.deleted_at IS NOT NULL THEN c.name || ' (deleted)' ELSE c.name END as category_name,
 			t.amount,
 			t.start_date,
 			t.end_date

--- a/internal/service/category_service.go
+++ b/internal/service/category_service.go
@@ -10,7 +10,7 @@ import (
 type CategoryService interface {
 	CreateCategory(ctx context.Context, category *model.Category) error
 	GetCategoryByID(ctx context.Context, id uint) (*model.Category, error)
-	GetCategories(ctx context.Context) ([]model.Category, error)
+	GetCategories(ctx context.Context, includeDeleted bool) ([]model.Category, error)
 	UpdateCategory(ctx context.Context, category *model.Category) error
 	DeleteCategory(ctx context.Context, id uint) error
 }
@@ -33,8 +33,8 @@ func (s *categoryService) GetCategoryByID(ctx context.Context, id uint) (*model.
 	return s.categoryRepo.FindByID(id)
 }
 
-func (s *categoryService) GetCategories(ctx context.Context) ([]model.Category, error) {
-	return s.categoryRepo.FindAll()
+func (s *categoryService) GetCategories(ctx context.Context, includeDeleted bool) ([]model.Category, error) {
+	return s.categoryRepo.FindAll(includeDeleted)
 }
 
 func (s *categoryService) UpdateCategory(ctx context.Context, category *model.Category) error {


### PR DESCRIPTION
Third batch of audit fixes, covering the approved D items.

## Changes

- **D1 — Database-level invariants**: `chk_transactions_shape` (recurring rows are schedules: `start_date` + `frequency`, no `date`; one-offs are dated rows with no schedule fields), `chk_transactions_dates` (`end_date >= start_date`), and `chk_transactions_amount_positive` (`NOT VALID`, so boot stays safe if an ancient row disagrees while new writes are protected). The migration repairs corrupted legacy rows first — clearing dangling schedule fields on one-offs (preserving what reports always showed), deriving missing dates/starts from `created_at`, and collapsing end-before-start schedules to a single month.
- **D4 — Versioned migrations, single schema owner**: a `schema_migrations` table records applied files; each migration now runs exactly once, inside a transaction with its version record (failed migrations leave no partial state). `AutoMigrate` is removed from startup. A small parity migration keeps the `deleted_at` index GORM used to create so fresh databases match existing ones. Existing databases bootstrap safely because every prior file was idempotent — they re-run once and get recorded.
- **D6 — Unique category names**: partial unique index on `lower(btrim(name))` for live categories (the locations pattern). Duplicate live categories are merged first: transactions move to the oldest duplicate, the rest are soft-deleted. `TranslateError` is enabled and the API returns **409** with a friendly message on duplicate create/update.
- **D7 — Deleted categories reported consistently**: metric queries label them `name (deleted)` instead of showing them unlabeled, and `GET /categories?include_deleted=true` exposes them for reporting consumers (the default remains live-only for the UI).

Also verified in passing: **D8** was already completed by the earlier F2 migration — `frequency` is the `transaction_frequency` enum (re-confirmed in this batch's smoke test).

## Verification

- `go build / vet / test` green.
- Live smoke test against Postgres 16 on a legacy database seeded with corrupted rows and duplicate categories:
  - boot 1 applied all 13 migrations once; boot 2 applied **0** (version table works);
  - all repairs landed (dangling schedule fields cleared, missing date backfilled, recurring `date` cleared, end-before-start collapsed);
  - duplicate `"  FOOD "` vs existing `Food` → 409; ` food `/`FOOD` merged into `Food` with transactions repointed;
  - after soft-deleting a category with spend, `average/by-category` returns `Hobby (deleted)` with the exact expected total;
  - an invalid-shape INSERT via raw SQL is rejected by the CHECK constraint.

Companion PR: the BFF change that consumes `include_deleted` and applies the same labels. Merge this first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVomed5rC3T2mnT5GCRbZY

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVomed5rC3T2mnT5GCRbZY)_