### PR TITLE
Remove the current-month projection endpoint

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -138,7 +138,6 @@ func setupRouter(cfg *config.Config, logger *slog.Logger, transactionHandler *ha
 			transactions.GET("/biggest", transactionHandler.GetBiggestTransactions)
 			transactions.GET("/average/by-type", transactionHandler.GetAverageByType)
 			transactions.GET("/average/by-category", transactionHandler.GetAverageByCategory)
-			transactions.GET("/projections/current-month", transactionHandler.GetCurrentMonthProjection)
 
 			reports := transactions.Group("/reports")
 			{

--- a/internal/handler/transaction_handler.go
+++ b/internal/handler/transaction_handler.go
@@ -811,18 +811,6 @@ func (h *TransactionHandler) GetAverageByType(c *gin.Context) {
 	})
 }
 
-func (h *TransactionHandler) GetCurrentMonthProjection(c *gin.Context) {
-	projection, err := h.transactionService.GetCurrentMonthProjection(c.Request.Context())
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "Failed to compute month projection",
-			"details": err.Error(),
-		})
-		return
-	}
-
-	c.JSON(http.StatusOK, projection)
-}
 
 func (h *TransactionHandler) GetAverageByCategory(c *gin.Context) {
 	var startDate, endDate *time.Time

--- a/internal/repository/transactions_repository.go
+++ b/internal/repository/transactions_repository.go
@@ -82,8 +82,6 @@ type TransactionsRepository interface {
 	FindRecurringExpensesInRange(startDate, endDate *time.Time) ([]RecurringCategoryExpense, error)
 	FindIncomeTotalInRange(startDate, endDate *time.Time) (float64, error)
 	FindRecurringIncomesInRange(startDate, endDate *time.Time) ([]RecurringAmount, error)
-	FindCurrentMonthRecurringExpenseTotal() (float64, error)
-	FindMonthToDateOneOffExpenseTotal() (float64, error)
 	FindCurrentMonthTotalByType(transactionType string) (float64, error)
 	FindCurrentMonthTotalByTypeAndCategory(transactionType string, categoryID uint) (float64, error)
 	FindNonRecurringMonthlyTotalsByType() ([]MonthlyTypeTotal, error)
@@ -220,49 +218,6 @@ func (r *transactionsRepository) CountAllWithFilters(currentMonth bool, category
 	return count, err
 }
 
-// FindCurrentMonthRecurringExpenseTotal sums the monthly amounts of every
-// recurring expense schedule active in the current month.
-func (r *transactionsRepository) FindCurrentMonthRecurringExpenseTotal() (float64, error) {
-	now := time.Now().In(r.loc)
-	start, end := monthBounds(now.Year(), now.Month(), r.loc)
-
-	var result struct {
-		Total float64 `gorm:"column:total"`
-	}
-	err := r.db.Raw(`
-		SELECT COALESCE(SUM(amount), 0) as total
-		FROM transactions
-		WHERE type = 'expense'
-		  AND is_recurring = true
-		  AND deleted_at IS NULL
-		  AND start_date < ?
-		  AND (end_date IS NULL OR end_date >= ?)
-	`, end.Format("2006-01-02"), start.Format("2006-01-02")).Scan(&result).Error
-	return result.Total, err
-}
-
-// FindMonthToDateOneOffExpenseTotal sums one-off expenses from the start of
-// the current month through the end of today (prepay lumps excluded).
-func (r *transactionsRepository) FindMonthToDateOneOffExpenseTotal() (float64, error) {
-	now := time.Now().In(r.loc)
-	start, _ := monthBounds(now.Year(), now.Month(), r.loc)
-	endOfToday := time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, r.loc)
-
-	var result struct {
-		Total float64 `gorm:"column:total"`
-	}
-	err := r.db.Raw(`
-		SELECT COALESCE(SUM(amount), 0) as total
-		FROM transactions
-		WHERE type = 'expense'
-		  AND is_recurring = false
-		  AND prepaid_from_id IS NULL
-		  AND deleted_at IS NULL
-		  AND date >= ?
-		  AND date < ?
-	`, start, endOfToday).Scan(&result).Error
-	return result.Total, err
-}
 
 func (r *transactionsRepository) FindLatest() ([]model.Transaction, error) {
 	var transactions []model.Transaction

--- a/internal/service/transactions_service.go
+++ b/internal/service/transactions_service.go
@@ -43,7 +43,6 @@ type TransactionsService interface {
 	CreateTransaction(ctx context.Context, transaction *model.Transaction) error
 	GetAverageByType(ctx context.Context, windowMonths int) ([]AverageType, error)
 	GetAverageByCategory(ctx context.Context, startDate, endDate *time.Time) ([]AverageByCategory, float64, error)
-	GetCurrentMonthProjection(ctx context.Context) (*MonthProjection, error)
 	GetTransactionByID(ctx context.Context, id uint) (*model.Transaction, error)
 	GetTransactions(ctx context.Context, limit, offset int) ([]model.Transaction, int64, error)
 	GetTransactionsWithFilters(ctx context.Context, currentMonth bool, categoryIDs []uint, searchQuery string, startDate, endDate *time.Time, transactionType string, limit, offset int) ([]model.Transaction, int64, error)
@@ -503,46 +502,6 @@ func (s *transactionsService) GetAverageByCategory(ctx context.Context, startDat
 	}
 
 	return result, incomeTotal, nil
-}
-
-type MonthProjection struct {
-	Month              string  `json:"month"`
-	RecurringCommitted float64 `json:"recurring_committed"`
-	OneOffSpent        float64 `json:"one_off_spent"`
-	ProjectedOneOff    float64 `json:"projected_one_off"`
-	ProjectedTotal     float64 `json:"projected_total"`
-}
-
-// projectMonth extrapolates end-of-month spending: recurring commitments are
-// fixed, one-off spending continues at the month-to-date daily run rate.
-func projectMonth(now time.Time, recurringCommitted, oneOffSpent float64) *MonthProjection {
-	daysInMonth := time.Date(now.Year(), now.Month()+1, 0, 0, 0, 0, 0, now.Location()).Day()
-	elapsedDays := now.Day()
-
-	projectedOneOff := oneOffSpent / float64(elapsedDays) * float64(daysInMonth)
-
-	return &MonthProjection{
-		Month:              now.Format("2006-01"),
-		RecurringCommitted: recurringCommitted,
-		OneOffSpent:        oneOffSpent,
-		ProjectedOneOff:    projectedOneOff,
-		ProjectedTotal:     recurringCommitted + projectedOneOff,
-	}
-}
-
-// GetCurrentMonthProjection estimates where this month's expenses will land
-// (M6): the recurring commitments already known plus one-off spending
-// extrapolated from the month-to-date run rate.
-func (s *transactionsService) GetCurrentMonthProjection(ctx context.Context) (*MonthProjection, error) {
-	recurring, err := s.transactionRepo.FindCurrentMonthRecurringExpenseTotal()
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch recurring expense total: %w", err)
-	}
-	oneOff, err := s.transactionRepo.FindMonthToDateOneOffExpenseTotal()
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch month-to-date expense total: %w", err)
-	}
-	return projectMonth(time.Now().In(s.loc), recurring, oneOff), nil
 }
 
 func (s *transactionsService) GetTransactionsByDateRange(ctx context.Context, startDate, endDate time.Time) ([]model.Transaction, error) {

--- a/internal/service/transactions_service_test.go
+++ b/internal/service/transactions_service_test.go
@@ -22,8 +22,6 @@ type mockTransactionsRepository struct {
 	recurringByType     []repository.RecurringTypeTransaction
 	incomeTotal         float64
 	recurringIncomes    []repository.RecurringAmount
-	recurringMonthly    float64
-	oneOffMonthToDate   float64
 	monthlyFlow         []repository.MonthlyFlowRow
 	categoryFlow        []repository.CategoryMonthlyFlowRow
 	categoryMonthTotals []repository.CategoryMonthTotal
@@ -66,14 +64,6 @@ func (m *mockTransactionsRepository) FindAllWithFilters(currentMonth bool, categ
 
 func (m *mockTransactionsRepository) CountAllWithFilters(currentMonth bool, categoryIDs []uint, searchQuery string, startDate, endDate *time.Time, transactionType string) (int64, error) {
 	return 0, nil
-}
-
-func (m *mockTransactionsRepository) FindCurrentMonthRecurringExpenseTotal() (float64, error) {
-	return m.recurringMonthly, nil
-}
-
-func (m *mockTransactionsRepository) FindMonthToDateOneOffExpenseTotal() (float64, error) {
-	return m.oneOffMonthToDate, nil
 }
 
 func (m *mockTransactionsRepository) FindBiggest(month, year int) ([]model.Transaction, error) {
@@ -580,44 +570,6 @@ func TestGetAverageByType_WindowClipsRecurringStart(t *testing.T) {
 	}
 	if math.Abs(result[0].Average-100) > 0.001 {
 		t.Errorf("expected average 100 over the window, got %v", result[0].Average)
-	}
-}
-
-// ---- projectMonth tests ----
-
-func TestProjectMonth(t *testing.T) {
-	// July 10th: R$500 one-off spent in 10 of 31 days → R$1,550 projected
-	// one-offs; plus R$800 in recurring commitments.
-	now := time.Date(2026, 7, 10, 15, 0, 0, 0, time.UTC)
-	p := projectMonth(now, 800, 500)
-
-	if p.Month != "2026-07" {
-		t.Errorf("expected month 2026-07, got %s", p.Month)
-	}
-	if p.RecurringCommitted != 800 {
-		t.Errorf("expected recurring 800, got %v", p.RecurringCommitted)
-	}
-	if p.OneOffSpent != 500 {
-		t.Errorf("expected one-off spent 500, got %v", p.OneOffSpent)
-	}
-	if math.Abs(p.ProjectedOneOff-1550) > 0.001 {
-		t.Errorf("expected projected one-off 1550, got %v", p.ProjectedOneOff)
-	}
-	if math.Abs(p.ProjectedTotal-2350) > 0.001 {
-		t.Errorf("expected projected total 2350, got %v", p.ProjectedTotal)
-	}
-}
-
-func TestProjectMonth_LastDayEqualsActuals(t *testing.T) {
-	// On the last day of the month the projection is just what was spent.
-	now := time.Date(2026, 6, 30, 23, 0, 0, 0, time.UTC)
-	p := projectMonth(now, 200, 900)
-
-	if math.Abs(p.ProjectedOneOff-900) > 0.001 {
-		t.Errorf("expected projected one-off 900, got %v", p.ProjectedOneOff)
-	}
-	if math.Abs(p.ProjectedTotal-1100) > 0.001 {
-		t.Errorf("expected projected total 1100, got %v", p.ProjectedTotal)
 	}
 }
 


### PR DESCRIPTION
Removes the "projected month spend" feature per user decision: the run-rate extrapolation was misleading — any large one-off purchase early in the month projected absurd totals (spend on day 4 multiplied by ~7.75×).

## Changes

- `GET /transactions/projections/current-month` route and handler removed
- `MonthProjection`, `projectMonth`, `GetCurrentMonthProjection` removed from the service
- `FindCurrentMonthRecurringExpenseTotal` / `FindMonthToDateOneOffExpenseTotal` removed from the repository
- Projection tests and mock methods removed

## Verification

- `go build / vet / test` green; repository integration tests green against Postgres 16; no references to the feature remain in any of the three repos.

Companion PRs remove the BFF proxy and the dashboard blocks. This can merge in any order relative to them (the frontend/BFF removals don't depend on the endpoint's absence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVomed5rC3T2mnT5GCRbZY

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVomed5rC3T2mnT5GCRbZY)_