### PR TITLE
Add identity service integration to enrich transactions with creator names

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -54,9 +54,14 @@ func main() {
 	locationService := service.NewLocationService(locationRepo)
 	locationHandler := handler.NewLocationHandler(locationService)
 
+	var identityClient service.IdentityClient
+	if cfg.Identity.BaseURL != "" {
+		identityClient = service.NewHTTPIdentityClient(cfg.Identity.BaseURL)
+	}
+
 	transactionRepo := repository.NewTransactionsRepository(db, reportingLoc)
 	transactionService := service.NewTransactionsService(transactionRepo, reportingLoc)
-	transactionHandler := handler.NewTransactionHandler(transactionService, locationService, reportingLoc)
+	transactionHandler := handler.NewTransactionHandler(transactionService, locationService, identityClient, reportingLoc)
 
 	categoryRepo := repository.NewCategoryRepository(db)
 	categoryService := service.NewCategoryService(categoryRepo)

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -36,7 +36,7 @@ services:
       DB_NAME: ${DB_NAME}
       SERVER_PORT: ${SERVER_PORT}
       LOG_LEVEL: ${LOG_LEVEL}
-      IDENTITY_BASE_URL: ${IDENTITY_BASE_URL:-http://identity:8080}
+      IDENTITY_BASE_URL: ${IDENTITY_BASE_URL:-http://identity-staging:8080}
     ports:
       - "${SERVICE_PORT}:${SERVER_PORT}"
     depends_on:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -36,6 +36,7 @@ services:
       DB_NAME: ${DB_NAME}
       SERVER_PORT: ${SERVER_PORT}
       LOG_LEVEL: ${LOG_LEVEL}
+      IDENTITY_BASE_URL: ${IDENTITY_BASE_URL:-http://identity:8080}
     ports:
       - "${SERVICE_PORT}:${SERVER_PORT}"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       DB_NAME: ${DB_NAME}
       SERVER_PORT: ${SERVER_PORT}
       LOG_LEVEL: ${LOG_LEVEL}
+      IDENTITY_BASE_URL: ${IDENTITY_BASE_URL:-http://identity:8080}
     ports:
       - "${SERVICE_PORT}:${SERVER_PORT}"
     depends_on:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,14 @@ type Config struct {
 	Database  DatabaseConfig
 	Log       LogConfig
 	Reporting ReportingConfig
+	Identity  IdentityConfig
+}
+
+type IdentityConfig struct {
+	// BaseURL is the identity service address reachable on the internal
+	// docker network. Used to resolve the display name of a transaction's
+	// creator. Empty disables enrichment.
+	BaseURL string
 }
 
 type ReportingConfig struct {
@@ -53,6 +61,9 @@ func Load() (*Config, error) {
 		},
 		Reporting: ReportingConfig{
 			Timezone: getEnv("REPORTING_TIMEZONE", "America/Sao_Paulo"),
+		},
+		Identity: IdentityConfig{
+			BaseURL: getEnv("IDENTITY_BASE_URL", "http://identity:8080"),
 		},
 	}
 

--- a/internal/handler/transaction_handler.go
+++ b/internal/handler/transaction_handler.go
@@ -16,13 +16,15 @@ import (
 type TransactionHandler struct {
 	transactionService service.TransactionsService
 	locationService    service.LocationService
+	identityClient     service.IdentityClient
 	loc                *time.Location
 }
 
-func NewTransactionHandler(transactionService service.TransactionsService, locationService service.LocationService, loc *time.Location) *TransactionHandler {
+func NewTransactionHandler(transactionService service.TransactionsService, locationService service.LocationService, identityClient service.IdentityClient, loc *time.Location) *TransactionHandler {
 	return &TransactionHandler{
 		transactionService: transactionService,
 		locationService:    locationService,
+		identityClient:     identityClient,
 		loc:                loc,
 	}
 }
@@ -170,6 +172,7 @@ func (h *TransactionHandler) CreateTransaction(c *gin.Context) {
 
 type TransactionDetailResponse struct {
 	*model.Transaction
+	CreatedByName        *string  `json:"created_by_name,omitempty"`
 	TotalPaid            *float64 `json:"total_paid,omitempty"`
 	TotalLeft            *float64 `json:"total_left,omitempty"`
 	CategoryMonthPercent *float64 `json:"category_month_percent,omitempty"`
@@ -213,6 +216,15 @@ func (h *TransactionHandler) GetTransactionByID(c *gin.Context) {
 	if percentages != nil {
 		resp.CategoryMonthPercent = percentages.CategoryMonthPercent
 		resp.TotalMonthPercent = percentages.TotalMonthPercent
+	}
+
+	// Best-effort enrichment: label the transaction with its creator's name
+	// from the identity service. A missing name (identity unavailable, user
+	// deleted, or legacy transaction with no creator) must not fail the read.
+	if h.identityClient != nil && transaction.CreatedById != 0 {
+		if name, err := h.identityClient.GetUserName(c.Request.Context(), transaction.CreatedById); err == nil && name != "" {
+			resp.CreatedByName = &name
+		}
 	}
 
 	c.JSON(http.StatusOK, resp)

--- a/internal/service/identity_client.go
+++ b/internal/service/identity_client.go
@@ -1,0 +1,66 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// IdentityClient resolves user information owned by the identity service.
+// Transactions store only a created_by_id; the display name lives in the
+// identity service and is fetched on demand.
+type IdentityClient interface {
+	// GetUserName returns the display name for the given user ID. It returns
+	// an error when the user cannot be resolved (not found, identity
+	// unavailable, etc.); callers should treat the name as unknown rather
+	// than fail their own request.
+	GetUserName(ctx context.Context, id uint) (string, error)
+}
+
+// HTTPIdentityClient talks to the identity service over the internal docker
+// network using its session-less public user lookup endpoint.
+type HTTPIdentityClient struct {
+	baseURL string
+	client  *http.Client
+}
+
+// NewHTTPIdentityClient builds a client targeting the given identity base URL
+// (e.g. http://identity:8080). A short timeout keeps a slow or unavailable
+// identity service from blocking transaction reads.
+func NewHTTPIdentityClient(baseURL string) *HTTPIdentityClient {
+	return &HTTPIdentityClient{
+		baseURL: baseURL,
+		client:  &http.Client{Timeout: 3 * time.Second},
+	}
+}
+
+func (c *HTTPIdentityClient) GetUserName(ctx context.Context, id uint) (string, error) {
+	url := fmt.Sprintf("%s/api/v1/internal/users/%d", c.baseURL, id)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to build identity request: %w", err)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to call identity service: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("identity service returned status %d", resp.StatusCode)
+	}
+
+	var body struct {
+		ID   uint   `json:"id"`
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", fmt.Errorf("failed to decode identity response: %w", err)
+	}
+
+	return body.Name, nil
+}

--- a/internal/service/identity_client_test.go
+++ b/internal/service/identity_client_test.go
@@ -1,0 +1,42 @@
+package service
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHTTPIdentityClient_GetUserName(t *testing.T) {
+	t.Run("returns the name for a known user", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/v1/internal/users/7" {
+				t.Errorf("unexpected path: %s", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":7,"name":"Arthur"}`))
+		}))
+		defer srv.Close()
+
+		client := NewHTTPIdentityClient(srv.URL)
+		name, err := client.GetUserName(context.Background(), 7)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if name != "Arthur" {
+			t.Fatalf("expected name %q, got %q", "Arthur", name)
+		}
+	})
+
+	t.Run("returns an error on non-200 status", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		client := NewHTTPIdentityClient(srv.URL)
+		if _, err := client.GetUserName(context.Background(), 99); err == nil {
+			t.Fatal("expected an error for a 404 response, got nil")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
This PR integrates with an identity service to enrich transaction details with the display name of the user who created them. The transaction creator is now resolved on-demand from the identity service and included in transaction read responses.

## Key Changes
- **New IdentityClient interface and HTTPIdentityClient implementation** (`internal/service/identity_client.go`): Provides a contract for resolving user information and implements HTTP-based communication with the identity service over the internal Docker network with a 3-second timeout
- **Transaction handler enrichment** (`internal/handler/transaction_handler.go`): 
  - Added `identityClient` dependency to `TransactionHandler`
  - Extended `TransactionDetailResponse` with optional `CreatedByName` field
  - Implemented best-effort enrichment in `GetTransactionByID` that gracefully handles identity service unavailability
- **Configuration support** (`internal/config/config.go`): Added `IdentityConfig` with configurable `BaseURL` for the identity service (defaults to `http://identity:8080`)
- **Dependency injection** (`cmd/server/main.go`): Conditionally instantiates `HTTPIdentityClient` when identity service URL is configured
- **Docker Compose updates**: Added `IDENTITY_BASE_URL` environment variable to both staging and production compose files

## Implementation Details
- The identity client lookup is **non-blocking**: failures to resolve a user name (service unavailable, user not found, network errors) do not fail the transaction read operation
- The implementation uses context-aware HTTP requests to respect request cancellation
- A short 3-second timeout prevents a slow or unavailable identity service from blocking transaction reads
- The enrichment is optional and can be disabled by leaving `IDENTITY_BASE_URL` empty
- Comprehensive test coverage for the identity client with success and error scenarios

https://claude.ai/code/session_01RVeTsY6CiPRQC4EfLjSWeN