### PR TITLE
Add insights cache invalidation via events service

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -61,7 +61,8 @@ func main() {
 
 	transactionRepo := repository.NewTransactionsRepository(db, reportingLoc)
 	transactionService := service.NewTransactionsService(transactionRepo, reportingLoc)
-	transactionHandler := handler.NewTransactionHandler(transactionService, locationService, identityClient, reportingLoc)
+	insightsNotifier := service.NewInsightsNotifier(cfg.Insights, transactionService, logger)
+	transactionHandler := handler.NewTransactionHandler(transactionService, locationService, identityClient, insightsNotifier, reportingLoc)
 
 	categoryRepo := repository.NewCategoryRepository(db)
 	categoryService := service.NewCategoryService(categoryRepo)

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -37,6 +37,11 @@ services:
       SERVER_PORT: ${SERVER_PORT}
       LOG_LEVEL: ${LOG_LEVEL}
       IDENTITY_BASE_URL: ${IDENTITY_BASE_URL:-http://identity-staging:8080}
+      # Insight cache invalidation: empty EVENTS_BASE_URL disables it.
+      EVENTS_BASE_URL: ${EVENTS_BASE_URL:-}
+      INSIGHTS_REBUILD_CALLBACK_URL: ${INSIGHTS_REBUILD_CALLBACK_URL:-http://ai-internal:3005/insights/rebuild}
+      INSIGHTS_SIGNIFICANT_AMOUNT: ${INSIGHTS_SIGNIFICANT_AMOUNT:-100}
+      INSIGHTS_SIGNIFICANT_MONTH_PERCENT: ${INSIGHTS_SIGNIFICANT_MONTH_PERCENT:-5}
     ports:
       - "${SERVICE_PORT}:${SERVER_PORT}"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,11 @@ services:
       SERVER_PORT: ${SERVER_PORT}
       LOG_LEVEL: ${LOG_LEVEL}
       IDENTITY_BASE_URL: ${IDENTITY_BASE_URL:-http://identity:8080}
+      # Insight cache invalidation: empty EVENTS_BASE_URL disables it.
+      EVENTS_BASE_URL: ${EVENTS_BASE_URL:-}
+      INSIGHTS_REBUILD_CALLBACK_URL: ${INSIGHTS_REBUILD_CALLBACK_URL:-http://ai-internal:3005/insights/rebuild}
+      INSIGHTS_SIGNIFICANT_AMOUNT: ${INSIGHTS_SIGNIFICANT_AMOUNT:-100}
+      INSIGHTS_SIGNIFICANT_MONTH_PERCENT: ${INSIGHTS_SIGNIFICANT_MONTH_PERCENT:-5}
     ports:
       - "${SERVICE_PORT}:${SERVER_PORT}"
     depends_on:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strconv"
 )
 
 type Config struct {
@@ -11,6 +12,22 @@ type Config struct {
 	Log       LogConfig
 	Reporting ReportingConfig
 	Identity  IdentityConfig
+	Insights  InsightsConfig
+}
+
+type InsightsConfig struct {
+	// EventsBaseURL is the events service address on the internal docker
+	// network. Empty disables insight rebuild notifications entirely.
+	EventsBaseURL string
+	// RebuildCallbackURL is where the events service delivers the
+	// rebuild-spending-insights job (ai-internal's GET /insights/rebuild).
+	RebuildCallbackURL string
+	// SignificantAmount is the absolute expense amount at which a new
+	// transaction invalidates the cached spending insight.
+	SignificantAmount float64
+	// SignificantMonthPercent invalidates when a new expense alone represents
+	// at least this percentage of the current month's total expenses.
+	SignificantMonthPercent float64
 }
 
 type IdentityConfig struct {
@@ -65,6 +82,12 @@ func Load() (*Config, error) {
 		Identity: IdentityConfig{
 			BaseURL: getEnv("IDENTITY_BASE_URL", "http://identity:8080"),
 		},
+		Insights: InsightsConfig{
+			EventsBaseURL:           getEnv("EVENTS_BASE_URL", ""),
+			RebuildCallbackURL:      getEnv("INSIGHTS_REBUILD_CALLBACK_URL", "http://ai-internal:3005/insights/rebuild"),
+			SignificantAmount:       getEnvFloat("INSIGHTS_SIGNIFICANT_AMOUNT", 100),
+			SignificantMonthPercent: getEnvFloat("INSIGHTS_SIGNIFICANT_MONTH_PERCENT", 5),
+		},
 	}
 
 	return cfg, nil
@@ -80,6 +103,15 @@ func (c *DatabaseConfig) DSN() string {
 func getEnv(key, defaultValue string) string {
 	if value := os.Getenv(key); value != "" {
 		return value
+	}
+	return defaultValue
+}
+
+func getEnvFloat(key string, defaultValue float64) float64 {
+	if value := os.Getenv(key); value != "" {
+		if parsed, err := strconv.ParseFloat(value, 64); err == nil {
+			return parsed
+		}
 	}
 	return defaultValue
 }

--- a/internal/handler/transaction_handler.go
+++ b/internal/handler/transaction_handler.go
@@ -17,14 +17,16 @@ type TransactionHandler struct {
 	transactionService service.TransactionsService
 	locationService    service.LocationService
 	identityClient     service.IdentityClient
+	insightsNotifier   service.InsightsNotifier
 	loc                *time.Location
 }
 
-func NewTransactionHandler(transactionService service.TransactionsService, locationService service.LocationService, identityClient service.IdentityClient, loc *time.Location) *TransactionHandler {
+func NewTransactionHandler(transactionService service.TransactionsService, locationService service.LocationService, identityClient service.IdentityClient, insightsNotifier service.InsightsNotifier, loc *time.Location) *TransactionHandler {
 	return &TransactionHandler{
 		transactionService: transactionService,
 		locationService:    locationService,
 		identityClient:     identityClient,
+		insightsNotifier:   insightsNotifier,
 		loc:                loc,
 	}
 }
@@ -162,6 +164,12 @@ func (h *TransactionHandler) CreateTransaction(c *gin.Context) {
 	if err := h.transactionService.CreateTransaction(c.Request.Context(), transaction); err != nil {
 		respondTransactionError(c, err, "Failed to create transaction")
 		return
+	}
+
+	// Fire-and-forget: a significant expense invalidates the cached AI
+	// spending insight via the events queue.
+	if h.insightsNotifier != nil {
+		h.insightsNotifier.TransactionCreated(transaction)
 	}
 
 	c.JSON(http.StatusCreated, gin.H{

--- a/internal/service/insights_notifier.go
+++ b/internal/service/insights_notifier.go
@@ -1,0 +1,168 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/ArthurWerle/transactions/internal/config"
+	"github.com/ArthurWerle/transactions/internal/model"
+)
+
+// RebuildInsightsJobType is the job enqueued on the events service when a
+// significant transaction invalidates the cached spending insight.
+const RebuildInsightsJobType = "rebuild-spending-insights"
+
+// InsightsNotifier invalidates the AI spending insight cache when a
+// transaction is significant enough to change the analysis. Notifications are
+// fire-and-forget: they never block or fail the transaction that triggered
+// them.
+type InsightsNotifier interface {
+	TransactionCreated(tx *model.Transaction)
+}
+
+// NewInsightsNotifier returns a notifier that enqueues a rebuild job on the
+// events service, or a no-op notifier when no events base URL is configured.
+func NewInsightsNotifier(cfg config.InsightsConfig, transactionService TransactionsService, logger *slog.Logger) InsightsNotifier {
+	if cfg.EventsBaseURL == "" {
+		logger.Info("insights notifier disabled: EVENTS_BASE_URL not set")
+		return noopInsightsNotifier{}
+	}
+	return &eventsInsightsNotifier{
+		cfg:                cfg,
+		transactionService: transactionService,
+		logger:             logger,
+		httpClient:         &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+type noopInsightsNotifier struct{}
+
+func (noopInsightsNotifier) TransactionCreated(*model.Transaction) {}
+
+type eventsInsightsNotifier struct {
+	cfg                config.InsightsConfig
+	transactionService TransactionsService
+	logger             *slog.Logger
+	httpClient         *http.Client
+}
+
+func (n *eventsInsightsNotifier) TransactionCreated(tx *model.Transaction) {
+	go n.notify(tx)
+}
+
+func (n *eventsInsightsNotifier) notify(tx *model.Transaction) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if !n.isSignificant(ctx, tx) {
+		return
+	}
+
+	if n.hasPendingRebuild(ctx) {
+		n.logger.Debug("insight rebuild already pending, skipping enqueue", "transaction_id", tx.ID)
+		return
+	}
+
+	if err := n.enqueueRebuild(ctx, tx); err != nil {
+		n.logger.Error("failed to enqueue insight rebuild", "error", err, "transaction_id", tx.ID)
+		return
+	}
+	n.logger.Info("enqueued insight rebuild", "transaction_id", tx.ID, "amount", tx.Amount)
+}
+
+// isSignificant decides whether the new expense should invalidate the cached
+// insight: either its absolute amount crosses the configured threshold, or it
+// alone represents a meaningful share of the current month's expenses.
+func (n *eventsInsightsNotifier) isSignificant(ctx context.Context, tx *model.Transaction) bool {
+	if tx.Type != string(model.Expense) {
+		return false
+	}
+	if n.cfg.SignificantAmount > 0 && tx.Amount >= n.cfg.SignificantAmount {
+		return true
+	}
+	if n.cfg.SignificantMonthPercent <= 0 {
+		return false
+	}
+
+	percentages, err := n.transactionService.GetTransactionMonthlyPercentages(ctx, tx)
+	if err != nil {
+		n.logger.Warn("failed to compute transaction significance", "error", err, "transaction_id", tx.ID)
+		return false
+	}
+	return percentages.TotalMonthPercent != nil &&
+		*percentages.TotalMonthPercent >= n.cfg.SignificantMonthPercent
+}
+
+// hasPendingRebuild checks (best-effort) whether a rebuild job is already
+// waiting in the queue, so a burst of significant transactions triggers a
+// single regeneration instead of one per transaction.
+func (n *eventsInsightsNotifier) hasPendingRebuild(ctx context.Context) bool {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, n.cfg.EventsBaseURL+"/api/events?status=pending", nil)
+	if err != nil {
+		return false
+	}
+	resp, err := n.httpClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
+
+	var events []struct {
+		JobType string `json:"job_type"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&events); err != nil {
+		return false
+	}
+	for _, event := range events {
+		if event.JobType == RebuildInsightsJobType {
+			return true
+		}
+	}
+	return false
+}
+
+func (n *eventsInsightsNotifier) enqueueRebuild(ctx context.Context, tx *model.Transaction) error {
+	payload, err := json.Marshal(map[string]interface{}{
+		"reason":         "significant_transaction_created",
+		"transaction_id": tx.ID,
+		"amount":         tx.Amount,
+		"category_id":    tx.CategoryID,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+
+	body, err := json.Marshal(map[string]string{
+		"job_type":     RebuildInsightsJobType,
+		"payload":      string(payload),
+		"callback_url": n.cfg.RebuildCallbackURL,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, n.cfg.EventsBaseURL+"/api/events", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := n.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
Implement automatic invalidation of AI spending insights cache when significant transactions are created. The system enqueues rebuild jobs to an external events service, which triggers insight regeneration asynchronously.

## Key Changes
- **New `InsightsNotifier` service** (`internal/service/insights_notifier.go`):
  - Fire-and-forget notifications that never block transaction creation
  - Determines transaction significance based on absolute amount or monthly percentage thresholds
  - Deduplicates rebuild jobs by checking for pending jobs in the events queue
  - Enqueues `rebuild-spending-insights` jobs with transaction context to the events service
  - Provides a no-op implementation when events service is not configured

- **Configuration updates** (`internal/config/config.go`):
  - Added `InsightsConfig` with four new environment variables:
    - `EVENTS_BASE_URL`: Events service endpoint (empty disables feature)
    - `INSIGHTS_REBUILD_CALLBACK_URL`: Where events service delivers rebuild jobs
    - `INSIGHTS_SIGNIFICANT_AMOUNT`: Absolute expense threshold (default: 100)
    - `INSIGHTS_SIGNIFICANT_MONTH_PERCENT`: Monthly percentage threshold (default: 5%)

- **Integration points**:
  - `TransactionHandler` now calls `insightsNotifier.TransactionCreated()` after successful transaction creation
  - Wired notifier in `cmd/server/main.go`
  - Updated Docker Compose files with new environment variables and documentation

## Implementation Details
- Notifications run asynchronously in goroutines to avoid blocking transaction responses
- Significance check queries monthly transaction percentages to determine if a transaction warrants cache invalidation
- Pending job deduplication prevents burst traffic from creating multiple rebuild jobs
- All HTTP operations use 10-30 second timeouts and gracefully degrade on errors (logged but not propagated)
- Feature is entirely optional and disabled when `EVENTS_BASE_URL` is not configured

https://claude.ai/code/session_01B6KkCgCbkthAG2i65Tri7q