### PR TITLE
Handle race condition in LocationService.FindOrCreate

### DIFF
--- a/internal/service/location_service.go
+++ b/internal/service/location_service.go
@@ -56,6 +56,13 @@ func (s *locationService) FindOrCreate(ctx context.Context, name string) (*model
 		NormalizedName: normalized,
 	}
 	if err := s.locationRepo.Create(location); err != nil {
+		// Concurrent requests for the same new location can both pass the
+		// lookup above and race on the insert; the unique index on
+		// normalized_name rejects the losers. Treat that as "found" and
+		// return the row the winning request created.
+		if errors.Is(err, gorm.ErrDuplicatedKey) {
+			return s.locationRepo.FindByNormalizedName(normalized)
+		}
 		return nil, err
 	}
 	return location, nil

--- a/internal/service/location_service_test.go
+++ b/internal/service/location_service_test.go
@@ -115,6 +115,40 @@ func TestFindOrCreate_CreatesDistinctNames(t *testing.T) {
 	}
 }
 
+// raceyLocationRepository simulates a concurrent request winning the insert
+// between our lookup and our create: the first FindByNormalizedName misses,
+// then Create fails with the unique-index error, and subsequent lookups find
+// the row the "other" request inserted.
+type raceyLocationRepository struct {
+	*mockLocationRepository
+	winner *model.Location
+}
+
+func (r *raceyLocationRepository) FindByNormalizedName(normalizedName string) (*model.Location, error) {
+	return r.mockLocationRepository.FindByNormalizedName(normalizedName)
+}
+
+func (r *raceyLocationRepository) Create(location *model.Location) error {
+	// The concurrent winner lands right before our insert.
+	r.winner = &model.Location{Name: location.Name, NormalizedName: location.NormalizedName}
+	r.winner.ID = 42
+	r.mockLocationRepository.locations[r.winner.ID] = r.winner
+	return gorm.ErrDuplicatedKey
+}
+
+func TestFindOrCreate_RecoversFromDuplicateKeyRace(t *testing.T) {
+	repo := &raceyLocationRepository{mockLocationRepository: newMockLocationRepository()}
+	svc := NewLocationService(repo)
+
+	got, err := svc.FindOrCreate(context.Background(), "SUPERMERCADO BROMBATTI")
+	if err != nil {
+		t.Fatalf("expected duplicate-key race to be recovered, got error: %v", err)
+	}
+	if got.ID != repo.winner.ID {
+		t.Errorf("expected the concurrently created location (id=%d), got id=%d", repo.winner.ID, got.ID)
+	}
+}
+
 func TestFindOrCreate_RejectsEmptyName(t *testing.T) {
 	svc := NewLocationService(newMockLocationRepository())
 	if _, err := svc.FindOrCreate(context.Background(), "   "); err == nil {


### PR DESCRIPTION
## Summary
Added handling for a race condition in `LocationService.FindOrCreate` where concurrent requests for the same new location can both pass the initial lookup and race on the insert operation. The unique index on `normalized_name` rejects the losing request, which is now treated as a successful "found" operation.

## Changes
- **location_service.go**: Added error handling in `FindOrCreate` to catch `gorm.ErrDuplicatedKey` errors and retry the lookup to return the location created by the winning concurrent request
- **location_service_test.go**: Added `TestFindOrCreate_RecoversFromDuplicateKeyRace` test with a `raceyLocationRepository` mock that simulates the race condition scenario

## Implementation Details
- When a duplicate key error occurs during `Create`, the service now performs a second `FindByNormalizedName` lookup to retrieve the location that was inserted by the concurrent winning request
- This approach is safe because the unique constraint guarantees that exactly one location with that normalized name exists in the database
- The test verifies that the service correctly recovers from this race condition and returns the location created by the concurrent request

https://claude.ai/code/session_01F8WqVYHXSrYCSh5tQRJfqx