### PR TITLE
Improve error messages in insights notifier HTTP requests

### DIFF
--- a/internal/service/insights_notifier.go
+++ b/internal/service/insights_notifier.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/ArthurWerle/transactions/internal/config"
@@ -157,12 +159,18 @@ func (n *eventsInsightsNotifier) enqueueRebuild(ctx context.Context, tx *model.T
 
 	resp, err := n.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
+		return fmt.Errorf("POST %s/api/events failed: %w", n.cfg.EventsBaseURL, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		return fmt.Errorf("unexpected status %d", resp.StatusCode)
+		// Include a bounded snippet of the response body so a rejected enqueue
+		// is debuggable instead of a bare status code.
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		if body := strings.TrimSpace(string(snippet)); body != "" {
+			return fmt.Errorf("POST %s/api/events returned %d: %s", n.cfg.EventsBaseURL, resp.StatusCode, body)
+		}
+		return fmt.Errorf("POST %s/api/events returned %d", n.cfg.EventsBaseURL, resp.StatusCode)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
Enhanced error handling and debugging in the `eventsInsightsNotifier.enqueueRebuild` method to provide more informative error messages when HTTP requests to the events API fail.

## Key Changes
- Added imports for `io` and `strings` packages to support response body inspection
- Improved error message for request failures to include the endpoint URL and HTTP method
- Enhanced error handling for non-201 status codes:
  - Now reads and includes a bounded snippet (up to 512 bytes) of the response body in error messages
  - Provides a fallback error message with just the status code if the response body is empty
  - Makes rejected enqueue operations debuggable instead of showing only a bare status code

## Implementation Details
- Response body is read with `io.LimitReader` to prevent unbounded memory consumption from large responses
- Response body snippet is trimmed of whitespace before inclusion in the error message
- Error messages now consistently include the full endpoint URL (`POST {baseURL}/api/events`) for better context

https://claude.ai/code/session_01Afw45xZBLraXvUStbhi4aX