### PR TITLE
Fix GORM auto-save associations clobbering subcategory FK updates

### DIFF
--- a/internal/handler/transaction_handler.go
+++ b/internal/handler/transaction_handler.go
@@ -538,6 +538,13 @@ func (h *TransactionHandler) UpdateTransaction(c *gin.Context) {
 		return
 	}
 
+	// Reload so the response carries fresh belongs-to associations
+	// (subcategory, location) matching the just-saved foreign keys instead of
+	// the stale ones preloaded before the update.
+	if reloaded, err := h.transactionService.GetTransactionByID(c.Request.Context(), id); err == nil {
+		transaction = reloaded
+	}
+
 	c.JSON(http.StatusOK, gin.H{
 		"message":     "Transaction updated successfully",
 		"transaction": transaction,

--- a/internal/repository/transactions_repository.go
+++ b/internal/repository/transactions_repository.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ArthurWerle/transactions/internal/model"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type CategoryExpenseSummary struct {
@@ -249,8 +250,15 @@ func (r *transactionsRepository) FindBiggest(month, year int) ([]model.Transacti
 	return transactions, err
 }
 
+// Update persists the transaction's own columns. It omits associations on
+// purpose: the caller resolves foreign keys explicitly (subcategory_id,
+// location_id), while the belongs-to structs (Subcategory, Location) are just
+// read projections preloaded by FindByID. Without this Omit, GORM's auto-save
+// of associations would upsert the stale preloaded association and overwrite
+// the foreign key back to its old value — silently discarding edits to
+// subcategory/location.
 func (r *transactionsRepository) Update(transaction *model.Transaction) error {
-	return r.db.Save(transaction).Error
+	return r.db.Omit(clause.Associations).Save(transaction).Error
 }
 
 func (r *transactionsRepository) Delete(id uint) error {

--- a/internal/repository/transactions_repository_integration_test.go
+++ b/internal/repository/transactions_repository_integration_test.go
@@ -87,6 +87,15 @@ func seedRecurring(t *testing.T, db *gorm.DB, catID uint, txType string, amount 
 	return tx
 }
 
+func seedSubcategory(t *testing.T, db *gorm.DB, name string) *model.Subcategory {
+	t.Helper()
+	s := &model.Subcategory{Name: name}
+	if err := db.Create(s).Error; err != nil {
+		t.Fatalf("failed to seed subcategory: %v", err)
+	}
+	return s
+}
+
 func TestIntegration_PeriodPredicateBoundaries(t *testing.T) {
 	db := setupIntegrationDB(t)
 	repo := NewTransactionsRepository(db, saoPaulo)
@@ -236,4 +245,67 @@ func TestIntegration_DuplicateCategoryTranslatesError(t *testing.T) {
 func datePtrAt(year int, month time.Month, day int) *time.Time {
 	d := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
 	return &d
+}
+
+// TestIntegration_UpdatePersistsSubcategoryChange guards against the GORM
+// auto-save-associations gotcha: FindByID preloads the belongs-to Subcategory,
+// and a plain Save would upsert that stale association and overwrite
+// subcategory_id back to its old value. Update must persist the new FK.
+func TestIntegration_UpdatePersistsSubcategoryChange(t *testing.T) {
+	db := setupIntegrationDB(t)
+	repo := NewTransactionsRepository(db, saoPaulo)
+	cat := seedCategory(t, db, "Groceries")
+	subA := seedSubcategory(t, db, "Old sub")
+	subB := seedSubcategory(t, db, "New sub")
+	// Stable expected values, never handed out as pointers: a buggy Update
+	// that clobbers the FK writes *through* the pointer we pass, so any uint
+	// used as a pointer target can be mutated out from under us.
+	wantOld, wantNew := subA.ID, subB.ID
+
+	tx := seedOneOff(t, db, cat.ID, "expense", 42, time.Date(2026, 7, 3, 14, 0, 0, 0, saoPaulo))
+	oldPtr := subA.ID
+	tx.SubcategoryID = &oldPtr
+	if err := repo.Update(tx); err != nil {
+		t.Fatalf("initial Update: %v", err)
+	}
+
+	// Reload the way the handler does — this preloads the stale Subcategory
+	// association that used to clobber the foreign key on Save.
+	loaded, err := repo.FindByID(tx.ID)
+	if err != nil {
+		t.Fatalf("FindByID: %v", err)
+	}
+	if loaded.SubcategoryID == nil || *loaded.SubcategoryID != wantOld {
+		t.Fatalf("setup: expected subcategory %d, got %v", wantOld, loaded.SubcategoryID)
+	}
+
+	// Change only the foreign key, leaving the preloaded association untouched.
+	newPtr := subB.ID
+	loaded.SubcategoryID = &newPtr
+	if err := repo.Update(loaded); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	// Ground truth: the persisted column, independent of any preload.
+	var rawFK *uint
+	if err := db.Raw("SELECT subcategory_id FROM transactions WHERE id = ?", tx.ID).Scan(&rawFK).Error; err != nil {
+		t.Fatalf("raw subcategory_id read: %v", err)
+	}
+	if rawFK == nil {
+		t.Fatalf("subcategory change did not persist in DB: want %d, got NULL", wantNew)
+	}
+	if *rawFK != wantNew {
+		t.Fatalf("subcategory change did not persist in DB: want %d, got %d", wantNew, *rawFK)
+	}
+
+	after, err := repo.FindByID(tx.ID)
+	if err != nil {
+		t.Fatalf("FindByID after update: %v", err)
+	}
+	if after.SubcategoryID == nil || *after.SubcategoryID != wantNew {
+		t.Fatalf("subcategory change did not persist: want %d, got %v", wantNew, after.SubcategoryID)
+	}
+	if after.Subcategory == nil || after.Subcategory.Name != "New sub" {
+		t.Errorf("preloaded subcategory should reflect the new value, got %+v", after.Subcategory)
+	}
 }


### PR DESCRIPTION
## Summary
Fixed a bug where updating a transaction's subcategory foreign key would be silently discarded due to GORM's auto-save-associations feature. When `FindByID` preloads the belongs-to `Subcategory` association and then `Save` is called, GORM would upsert the stale preloaded association and overwrite the foreign key back to its old value.

## Key Changes
- **transactions_repository.go**: Modified `Update()` to use `Omit(clause.Associations)` when saving, preventing GORM from auto-saving stale preloaded associations while still persisting the transaction's own columns and foreign keys
- **transaction_handler.go**: Added a reload after update to fetch fresh belongs-to associations (subcategory, location) that match the newly-saved foreign keys, ensuring the response reflects the actual persisted state
- **transactions_repository_integration_test.go**: 
  - Added `seedSubcategory()` helper function for test setup
  - Added comprehensive integration test `TestIntegration_UpdatePersistsSubcategoryChange` that verifies the fix by:
    - Creating a transaction with an initial subcategory
    - Reloading it (which preloads the stale association)
    - Changing the subcategory FK
    - Verifying the change persists in the database
    - Confirming the reloaded transaction reflects the new association

## Implementation Details
The root cause was GORM's default behavior of auto-saving all associations when `Save()` is called. Since the handler pattern loads transactions with preloaded associations before updates, those associations become stale. The fix uses `Omit(clause.Associations)` to skip association persistence while relying on explicit foreign key management. The handler then reloads the transaction to provide fresh association data in the response.

https://claude.ai/code/session_01TtNcqMA7AD3WsBK4eefZ86