### PR TITLE
Add daily-expenses and top-merchants report endpoints

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -161,6 +161,8 @@ func setupRouter(cfg *config.Config, logger *slog.Logger, transactionHandler *ha
 				reports.GET("/monthly-expenses-by-category", transactionHandler.GetMonthlyExpensesByCategory)
 				reports.GET("/monthly-expenses-by-subcategory", transactionHandler.GetMonthlyExpensesBySubcategory)
 				reports.GET("/monthly-expenses-by-location", transactionHandler.GetMonthlyExpensesByLocation)
+				reports.GET("/monthly-daily-expenses", transactionHandler.GetMonthlyDailyExpenses)
+				reports.GET("/monthly-merchants", transactionHandler.GetMonthlyMerchants)
 			}
 		}
 

--- a/internal/handler/transaction_handler.go
+++ b/internal/handler/transaction_handler.go
@@ -856,6 +856,44 @@ func (h *TransactionHandler) GetMonthlyExpensesByLocation(c *gin.Context) {
 	})
 }
 
+func (h *TransactionHandler) GetMonthlyDailyExpenses(c *gin.Context) {
+	month, year, ok := h.parseMonthYearParams(c)
+	if !ok {
+		return
+	}
+
+	result, err := h.transactionService.GetMonthlyDailyExpenses(c.Request.Context(), month, year)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   "Failed to fetch daily expenses",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+func (h *TransactionHandler) GetMonthlyMerchants(c *gin.Context) {
+	month, year, ok := h.parseMonthYearParams(c)
+	if !ok {
+		return
+	}
+
+	merchants, err := h.transactionService.GetMonthlyMerchants(c.Request.Context(), month, year)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   "Failed to fetch monthly merchants",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"merchants": merchants,
+	})
+}
+
 func (h *TransactionHandler) GetAverageByType(c *gin.Context) {
 	window := 0
 	if w := c.Query("window"); w != "" {

--- a/internal/repository/transactions_repository.go
+++ b/internal/repository/transactions_repository.go
@@ -72,6 +72,18 @@ type LocationMonthTotal struct {
 	Total        float64 `gorm:"column:total"`
 }
 
+type DailyExpenseTotal struct {
+	Day   time.Time `gorm:"column:day"`
+	Total float64   `gorm:"column:total"`
+}
+
+type MerchantMonthTotal struct {
+	Name             string  `gorm:"column:name"`
+	Total            float64 `gorm:"column:total"`
+	TransactionCount int64   `gorm:"column:transaction_count"`
+	TopCategory      string  `gorm:"column:top_category"`
+}
+
 type TransactionsRepository interface {
 	Create(transaction *model.Transaction) error
 	FindByID(id uint) (*model.Transaction, error)
@@ -90,6 +102,8 @@ type TransactionsRepository interface {
 	FindCategoryExpenseTotalsForMonth(month time.Time) ([]CategoryMonthTotal, error)
 	FindSubcategoryExpenseTotalsForMonth(month time.Time) ([]SubcategoryMonthTotal, error)
 	FindLocationExpenseTotalsForMonth(month time.Time) ([]LocationMonthTotal, error)
+	FindDailyExpenseTotalsForMonth(month time.Time) ([]DailyExpenseTotal, int64, error)
+	FindMerchantExpenseTotalsForMonth(month time.Time) ([]MerchantMonthTotal, error)
 	FindEarliestDate(startDate, endDate *time.Time) (*time.Time, error)
 	FindExpenseSummaryByCategory(startDate, endDate *time.Time) ([]CategoryExpenseSummary, error)
 	FindRecurringExpensesInRange(startDate, endDate *time.Time) ([]RecurringCategoryExpense, error)
@@ -471,6 +485,130 @@ func (r *transactionsRepository) FindLocationExpenseTotalsForMonth(month time.Ti
 		LEFT JOIN locations l ON l.id = a.location_id
 		GROUP BY l.name, l.deleted_at
 		ORDER BY total DESC
+	`, tz, monthStr, monthStr, monthStr).Scan(&results).Error
+	return results, err
+}
+
+// FindDailyExpenseTotalsForMonth returns one zero-filled row per calendar day of
+// the month with that day's expense total, plus the month's expense transaction
+// count. One-off expenses bucket by their reporting-timezone calendar day;
+// each recurring expense schedule active in the month is attributed to a single
+// day (its start_date day-of-month, clamped to the month's length), so the daily
+// sum reconciles with the monthly total. Prepayment rows are excluded.
+func (r *transactionsRepository) FindDailyExpenseTotalsForMonth(month time.Time) ([]DailyExpenseTotal, int64, error) {
+	var results []DailyExpenseTotal
+	tz := r.loc.String()
+	monthStr := month.Format("2006-01-02")
+	err := r.db.Raw(`
+		WITH days AS (
+			SELECT generate_series(?::date, (?::date + interval '1 month - 1 day')::date, interval '1 day')::date AS day
+		),
+		activity AS (
+			SELECT date_trunc('day', t.date AT TIME ZONE ?)::date AS day, t.amount
+			FROM transactions t
+			WHERE t.is_recurring = false
+			  AND t.type = 'expense'
+			  AND t.date IS NOT NULL
+			  AND t.deleted_at IS NULL
+			  AND t.prepaid_from_id IS NULL
+			  AND date_trunc('month', t.date AT TIME ZONE ?)::date = ?::date
+			UNION ALL
+			SELECT (?::date + (LEAST(
+			            EXTRACT(day FROM t.start_date)::int,
+			            EXTRACT(day FROM (?::date + interval '1 month - 1 day'))::int
+			        ) - 1) * interval '1 day')::date AS day,
+			       t.amount
+			FROM transactions t
+			WHERE t.is_recurring = true
+			  AND t.type = 'expense'
+			  AND t.deleted_at IS NULL
+			  AND t.start_date < (?::date + interval '1 month')::date
+			  AND (t.end_date IS NULL OR t.end_date >= ?::date)
+		)
+		SELECT d.day, COALESCE(SUM(a.amount), 0) AS total
+		FROM days d
+		LEFT JOIN activity a ON a.day = d.day
+		GROUP BY d.day
+		ORDER BY d.day
+	`, monthStr, monthStr, tz, tz, monthStr, monthStr, monthStr, monthStr, monthStr).Scan(&results).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var count int64
+	err = r.db.Raw(`
+		SELECT
+		  (SELECT COUNT(*) FROM transactions t
+		     WHERE t.is_recurring = false AND t.type = 'expense' AND t.date IS NOT NULL
+		       AND t.deleted_at IS NULL AND t.prepaid_from_id IS NULL
+		       AND date_trunc('month', t.date AT TIME ZONE ?)::date = ?::date)
+		  +
+		  (SELECT COUNT(*) FROM transactions t
+		     WHERE t.is_recurring = true AND t.type = 'expense' AND t.deleted_at IS NULL
+		       AND t.start_date < (?::date + interval '1 month')::date
+		       AND (t.end_date IS NULL OR t.end_date >= ?::date)) AS count
+	`, tz, monthStr, monthStr, monthStr).Scan(&count).Error
+	if err != nil {
+		return nil, 0, err
+	}
+	return results, count, nil
+}
+
+// FindMerchantExpenseTotalsForMonth returns each location's expense total for the
+// month with its transaction count and dominant category (the category with the
+// largest spend at that location that month), largest total first. Merchant =
+// location; transactions with no location fold into "(none)". Mirrors the
+// activity CTE used by the other month aggregations (one-off dated + recurring
+// active, prepaid excluded, tz-aware). Soft-deleted names are labelled.
+func (r *transactionsRepository) FindMerchantExpenseTotalsForMonth(month time.Time) ([]MerchantMonthTotal, error) {
+	var results []MerchantMonthTotal
+	tz := r.loc.String()
+	monthStr := month.Format("2006-01-02")
+	err := r.db.Raw(`
+		WITH activity AS (
+			SELECT t.location_id, t.category_id, t.amount
+			FROM transactions t
+			WHERE t.is_recurring = false
+			  AND t.type = 'expense'
+			  AND t.date IS NOT NULL
+			  AND t.deleted_at IS NULL
+			  AND t.prepaid_from_id IS NULL
+			  AND date_trunc('month', t.date AT TIME ZONE ?)::date = ?::date
+			UNION ALL
+			SELECT t.location_id, t.category_id, t.amount
+			FROM transactions t
+			WHERE t.is_recurring = true
+			  AND t.type = 'expense'
+			  AND t.deleted_at IS NULL
+			  AND t.start_date < (?::date + interval '1 month')::date
+			  AND (t.end_date IS NULL OR t.end_date >= ?::date)
+		),
+		per_loc AS (
+			SELECT location_id, SUM(amount) AS total, COUNT(*) AS transaction_count
+			FROM activity
+			GROUP BY location_id
+		),
+		per_loc_cat AS (
+			SELECT location_id, category_id,
+			       ROW_NUMBER() OVER (PARTITION BY location_id ORDER BY SUM(amount) DESC, category_id) AS rn
+			FROM activity
+			GROUP BY location_id, category_id
+		),
+		top_cat AS (
+			SELECT plc.location_id,
+			       CASE WHEN c.deleted_at IS NOT NULL THEN c.name || ' (deleted)' ELSE c.name END AS top_category
+			FROM per_loc_cat plc
+			LEFT JOIN categories c ON c.id = plc.category_id
+			WHERE plc.rn = 1
+		)
+		SELECT COALESCE(CASE WHEN l.deleted_at IS NOT NULL THEN l.name || ' (deleted)' ELSE l.name END, '(none)') AS name,
+		       pl.total,
+		       pl.transaction_count,
+		       COALESCE(tc.top_category, '') AS top_category
+		FROM per_loc pl
+		LEFT JOIN locations l ON l.id = pl.location_id
+		LEFT JOIN top_cat tc ON tc.location_id IS NOT DISTINCT FROM pl.location_id
+		ORDER BY pl.total DESC
 	`, tz, monthStr, monthStr, monthStr).Scan(&results).Error
 	return results, err
 }

--- a/internal/repository/transactions_repository_integration_test.go
+++ b/internal/repository/transactions_repository_integration_test.go
@@ -226,6 +226,115 @@ func TestIntegration_CategoryMonthTotalsLabelDeleted(t *testing.T) {
 	}
 }
 
+func seedLocation(t *testing.T, db *gorm.DB, name string) *model.Location {
+	t.Helper()
+	l := &model.Location{Name: name, NormalizedName: name}
+	if err := db.Create(l).Error; err != nil {
+		t.Fatalf("failed to seed location: %v", err)
+	}
+	return l
+}
+
+func seedOneOffLoc(t *testing.T, db *gorm.DB, catID uint, locID *uint, amount float64, date time.Time) {
+	t.Helper()
+	tx := &model.Transaction{CategoryID: catID, LocationID: locID, Type: "expense", Amount: amount, Date: &date}
+	if err := db.Create(tx).Error; err != nil {
+		t.Fatalf("failed to seed located one-off: %v", err)
+	}
+}
+
+func TestIntegration_DailyExpenseTotalsForMonth(t *testing.T) {
+	db := setupIntegrationDB(t)
+	repo := NewTransactionsRepository(db, saoPaulo)
+	cat := seedCategory(t, db, "Daily")
+
+	// Two one-off expenses on June 3rd (BRT) → that day totals 150.
+	seedOneOff(t, db, cat.ID, "expense", 100, time.Date(2026, 6, 3, 14, 0, 0, 0, saoPaulo))
+	seedOneOff(t, db, cat.ID, "expense", 50, time.Date(2026, 6, 3, 18, 0, 0, 0, saoPaulo))
+	// Income must not count toward expenses.
+	seedOneOff(t, db, cat.ID, "income", 999, time.Date(2026, 6, 5, 12, 0, 0, 0, saoPaulo))
+	// Recurring day-15 schedule active in June → attributed to June 15.
+	seedRecurring(t, db, cat.ID, "expense", 200, time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC), nil)
+	// Recurring day-31 schedule → clamped to the last day of June (30th).
+	seedRecurring(t, db, cat.ID, "expense", 300, time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC), nil)
+	// Recurring starting after June must not appear.
+	seedRecurring(t, db, cat.ID, "expense", 70, time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC), nil)
+	// A prepayment lump is a cash record excluded from aggregates.
+	lumpDate := time.Date(2026, 6, 20, 12, 0, 0, 0, saoPaulo)
+	original := seedRecurring(t, db, cat.ID, "expense", 10, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), datePtrAt(2026, 1, 31))
+	lump := &model.Transaction{CategoryID: cat.ID, Type: "expense", Amount: 1500, Date: &lumpDate, PrepaidFromID: &original.ID}
+	if err := db.Create(lump).Error; err != nil {
+		t.Fatalf("failed to seed prepay lump: %v", err)
+	}
+
+	days, count, err := repo.FindDailyExpenseTotalsForMonth(time.Date(2026, 6, 1, 0, 0, 0, 0, saoPaulo))
+	if err != nil {
+		t.Fatalf("FindDailyExpenseTotalsForMonth: %v", err)
+	}
+	if len(days) != 30 {
+		t.Fatalf("June has 30 days (zero-filled), got %d", len(days))
+	}
+
+	byDay := map[int]float64{}
+	var sum float64
+	for _, d := range days {
+		byDay[d.Day.Day()] = d.Total
+		sum += d.Total
+	}
+	if byDay[3] != 150 {
+		t.Errorf("June 3 total = %v, expected 150", byDay[3])
+	}
+	if byDay[15] != 200 {
+		t.Errorf("June 15 total = %v, expected 200 (recurring day-15)", byDay[15])
+	}
+	if byDay[30] != 300 {
+		t.Errorf("June 30 total = %v, expected 300 (recurring day-31 clamped)", byDay[30])
+	}
+	if sum != 650 {
+		t.Errorf("daily sum = %v, expected 650 (income + prepay + future-recurring excluded)", sum)
+	}
+	// 2 one-off expenses + 2 active recurring expenses = 4.
+	if count != 4 {
+		t.Errorf("transaction_count = %d, expected 4", count)
+	}
+}
+
+func TestIntegration_MerchantExpenseTotalsForMonth(t *testing.T) {
+	db := setupIntegrationDB(t)
+	repo := NewTransactionsRepository(db, saoPaulo)
+	groceries := seedCategory(t, db, "Groceries")
+	coffee := seedCategory(t, db, "Coffee")
+	market := seedLocation(t, db, "Supermarket")
+	cafe := seedLocation(t, db, "Cafe")
+
+	// Supermarket: Groceries 300 (2 tx) + Coffee 10 (1 tx) → top category Groceries.
+	seedOneOffLoc(t, db, groceries.ID, &market.ID, 100, time.Date(2026, 6, 3, 12, 0, 0, 0, saoPaulo))
+	seedOneOffLoc(t, db, groceries.ID, &market.ID, 200, time.Date(2026, 6, 10, 12, 0, 0, 0, saoPaulo))
+	seedOneOffLoc(t, db, coffee.ID, &market.ID, 10, time.Date(2026, 6, 11, 12, 0, 0, 0, saoPaulo))
+	// Cafe: Coffee 40 (1 tx).
+	seedOneOffLoc(t, db, coffee.ID, &cafe.ID, 40, time.Date(2026, 6, 5, 12, 0, 0, 0, saoPaulo))
+	// No location → folds into "(none)".
+	seedOneOffLoc(t, db, groceries.ID, nil, 30, time.Date(2026, 6, 7, 12, 0, 0, 0, saoPaulo))
+
+	rows, err := repo.FindMerchantExpenseTotalsForMonth(time.Date(2026, 6, 1, 0, 0, 0, 0, saoPaulo))
+	if err != nil {
+		t.Fatalf("FindMerchantExpenseTotalsForMonth: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 merchants, got %d", len(rows))
+	}
+	// Ordered by total desc: Supermarket 310, Cafe 40, (none) 30.
+	if rows[0].Name != "Supermarket" || rows[0].Total != 310 || rows[0].TransactionCount != 3 || rows[0].TopCategory != "Groceries" {
+		t.Errorf("unexpected Supermarket row: %+v", rows[0])
+	}
+	if rows[1].Name != "Cafe" || rows[1].Total != 40 || rows[1].TransactionCount != 1 || rows[1].TopCategory != "Coffee" {
+		t.Errorf("unexpected Cafe row: %+v", rows[1])
+	}
+	if rows[2].Name != "(none)" || rows[2].Total != 30 || rows[2].TransactionCount != 1 {
+		t.Errorf("expected the (none) bucket last, got %+v", rows[2])
+	}
+}
+
 func TestIntegration_DuplicateCategoryTranslatesError(t *testing.T) {
 	db := setupIntegrationDB(t)
 	repo := NewCategoryRepository(db)

--- a/internal/service/reports_test.go
+++ b/internal/service/reports_test.go
@@ -244,3 +244,58 @@ func TestGetMonthlyExpensesByLocation(t *testing.T) {
 		t.Errorf("expected the (none) bucket preserved, got %+v", got[1])
 	}
 }
+
+func TestGetMonthlyDailyExpenses_FormatsDaysAndSumsTotal(t *testing.T) {
+	repo := newMockRepository()
+	svc := newTestService(repo)
+
+	// The repository already zero-fills every day; the service formats each
+	// day's date and sums the totals (which reconcile with the monthly total).
+	repo.dailyExpenseTotals = []repository.DailyExpenseTotal{
+		{Day: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC), Total: 10},
+		{Day: time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC), Total: 0},
+		{Day: time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC), Total: 25.5},
+	}
+	repo.dailyExpenseCount = 7
+
+	got, err := svc.GetMonthlyDailyExpenses(context.Background(), 6, 2026)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Days) != 3 {
+		t.Fatalf("expected 3 days, got %d", len(got.Days))
+	}
+	if got.Days[0].Date != "2026-06-01" || got.Days[0].Total != 10 {
+		t.Errorf("unexpected first day: %+v", got.Days[0])
+	}
+	if got.TransactionCount != 7 {
+		t.Errorf("expected count 7, got %d", got.TransactionCount)
+	}
+	if got.Total != 35.5 {
+		t.Errorf("expected summed total 35.5, got %v", got.Total)
+	}
+}
+
+func TestGetMonthlyMerchants_PassesThroughRows(t *testing.T) {
+	repo := newMockRepository()
+	svc := newTestService(repo)
+
+	repo.merchantMonthTotals = []repository.MerchantMonthTotal{
+		{Name: "Supermarket", Total: 400, TransactionCount: 12, TopCategory: "Groceries"},
+		{Name: "(none)", Total: 75, TransactionCount: 3, TopCategory: "Misc"},
+	}
+
+	got, err := svc.GetMonthlyMerchants(context.Background(), 6, 2026)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(got))
+	}
+	if got[0].Name != "Supermarket" || got[0].Total != 400 || got[0].TransactionCount != 12 || got[0].TopCategory != "Groceries" {
+		t.Errorf("unexpected first merchant: %+v", got[0])
+	}
+	if got[1].Name != "(none)" || got[1].TransactionCount != 3 {
+		t.Errorf("expected the (none) bucket preserved, got %+v", got[1])
+	}
+}

--- a/internal/service/transactions_service.go
+++ b/internal/service/transactions_service.go
@@ -57,6 +57,8 @@ type TransactionsService interface {
 	GetMonthlyExpensesByCategory(ctx context.Context, month, year int) ([]CategoryMonthExpense, error)
 	GetMonthlyExpensesBySubcategory(ctx context.Context, month, year int) ([]SubcategoryMonthExpense, error)
 	GetMonthlyExpensesByLocation(ctx context.Context, month, year int) ([]LocationMonthExpense, error)
+	GetMonthlyDailyExpenses(ctx context.Context, month, year int) (*DailyExpensesResult, error)
+	GetMonthlyMerchants(ctx context.Context, month, year int) ([]MerchantMonthExpense, error)
 	PrepayTransaction(ctx context.Context, id uint) (*PrepayResult, error)
 	GetTransactionMonthlyPercentages(ctx context.Context, tx *model.Transaction) (*TransactionPercentages, error)
 }
@@ -699,6 +701,64 @@ func (s *transactionsService) GetMonthlyExpensesByLocation(ctx context.Context, 
 	result := make([]LocationMonthExpense, 0, len(rows))
 	for _, row := range rows {
 		result = append(result, LocationMonthExpense{LocationName: row.LocationName, Total: row.Total})
+	}
+	return result, nil
+}
+
+type DailyExpensePoint struct {
+	Date  string  `json:"date"` // YYYY-MM-DD
+	Total float64 `json:"total"`
+}
+
+type DailyExpensesResult struct {
+	Days             []DailyExpensePoint `json:"days"`
+	TransactionCount int64               `json:"transaction_count"`
+	Total            float64             `json:"total"`
+}
+
+// GetMonthlyDailyExpenses returns one zero-filled point per calendar day of the
+// month with that day's expense total, plus the month's expense transaction
+// count and the summed total (which reconciles with the monthly overview).
+func (s *transactionsService) GetMonthlyDailyExpenses(ctx context.Context, month, year int) (*DailyExpensesResult, error) {
+	target := time.Date(year, time.Month(month), 1, 0, 0, 0, 0, s.loc)
+	rows, count, err := s.transactionRepo.FindDailyExpenseTotalsForMonth(target)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch daily expense totals: %w", err)
+	}
+
+	days := make([]DailyExpensePoint, 0, len(rows))
+	var total float64
+	for _, row := range rows {
+		days = append(days, DailyExpensePoint{Date: row.Day.Format("2006-01-02"), Total: row.Total})
+		total += row.Total
+	}
+	return &DailyExpensesResult{Days: days, TransactionCount: count, Total: total}, nil
+}
+
+type MerchantMonthExpense struct {
+	Name             string  `json:"name"`
+	Total            float64 `json:"total"`
+	TransactionCount int64   `json:"transaction_count"`
+	TopCategory      string  `json:"top_category"`
+}
+
+// GetMonthlyMerchants returns each merchant (location) expense total for the
+// month with its transaction count and dominant category, largest first.
+func (s *transactionsService) GetMonthlyMerchants(ctx context.Context, month, year int) ([]MerchantMonthExpense, error) {
+	target := time.Date(year, time.Month(month), 1, 0, 0, 0, 0, s.loc)
+	rows, err := s.transactionRepo.FindMerchantExpenseTotalsForMonth(target)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch merchant totals: %w", err)
+	}
+
+	result := make([]MerchantMonthExpense, 0, len(rows))
+	for _, row := range rows {
+		result = append(result, MerchantMonthExpense{
+			Name:             row.Name,
+			Total:            row.Total,
+			TransactionCount: row.TransactionCount,
+			TopCategory:      row.TopCategory,
+		})
 	}
 	return result, nil
 }

--- a/internal/service/transactions_service_test.go
+++ b/internal/service/transactions_service_test.go
@@ -27,6 +27,9 @@ type mockTransactionsRepository struct {
 	categoryMonthTotals    []repository.CategoryMonthTotal
 	subcategoryMonthTotals []repository.SubcategoryMonthTotal
 	locationMonthTotals    []repository.LocationMonthTotal
+	dailyExpenseTotals     []repository.DailyExpenseTotal
+	dailyExpenseCount      int64
+	merchantMonthTotals    []repository.MerchantMonthTotal
 }
 
 func newMockRepository() *mockTransactionsRepository {
@@ -107,6 +110,14 @@ func (m *mockTransactionsRepository) FindSubcategoryExpenseTotalsForMonth(month 
 
 func (m *mockTransactionsRepository) FindLocationExpenseTotalsForMonth(month time.Time) ([]repository.LocationMonthTotal, error) {
 	return m.locationMonthTotals, nil
+}
+
+func (m *mockTransactionsRepository) FindDailyExpenseTotalsForMonth(month time.Time) ([]repository.DailyExpenseTotal, int64, error) {
+	return m.dailyExpenseTotals, m.dailyExpenseCount, nil
+}
+
+func (m *mockTransactionsRepository) FindMerchantExpenseTotalsForMonth(month time.Time) ([]repository.MerchantMonthTotal, error) {
+	return m.merchantMonthTotals, nil
 }
 
 func (m *mockTransactionsRepository) FindByPrepaidID(prepaidID uint) (*model.Transaction, error) {


### PR DESCRIPTION
## Why

The `reports` service is being redesigned into a richer monthly report (see the paired PR in `ArthurWerle/reports`). Two of its new sections need aggregates the transactions API doesn't expose yet: a per-day spend series (for the hero daily-spend chart) and a merchant breakdown. This PR adds those two read endpoints.

## What

Two new endpoints under `/api/v2/transactions/reports`:

**`GET /monthly-daily-expenses?month=&year=`**
```json
{ "days": [{"date":"2025-06-01","total":12.34}, … one per day, zero-filled …],
  "transaction_count": 87,
  "total": 4321.00 }
```

**`GET /monthly-merchants?month=&year=`**
```json
{ "merchants": [{"name":"Supermarket","total":400.0,"transaction_count":12,"top_category":"Groceries"}] }
```
Merchant = location; `top_category` is the category with the largest spend at that location that month; null location folds into `(none)`.

Both mirror the existing month-aggregation conventions used by `monthly-expenses-by-*`: one-off dated transactions **plus** recurring schedules active in the month, `prepaid_from_id` rows excluded, timezone-aware bucketing, and soft-deleted names labelled. Recurring expenses in the daily series are attributed to a single day (their `start_date` day-of-month, clamped to the month length) so the daily totals reconcile with the monthly total.

## Changes
- `internal/repository`: `FindDailyExpenseTotalsForMonth`, `FindMerchantExpenseTotalsForMonth`
- `internal/service`: `GetMonthlyDailyExpenses`, `GetMonthlyMerchants` (+ result types)
- `internal/handler` + `cmd/server`: two handlers and routes (reuse the existing `parseMonthYearParams`)

## Testing
- Service shaping tests (mock repo) — always run.
- Repository integration cases for the new SQL (recurring attribution, tz bucketing, `(none)` bucket, top-category) — skip without `TEST_DATABASE_DSN`.
- `go build ./...`, `go vet ./...`, and `go test ./...` all pass; integration tests verified green against a real Postgres 16.

Nothing existing changes behavior — this PR is purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGzEGboX24V2jeoh9WrtoH

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGzEGboX24V2jeoh9WrtoH)_